### PR TITLE
[SCRUM-51] bugfix - 최신 말씀 데이터가 아닌 이전 말씀 데이터가 나옴

### DIFF
--- a/src/components/WidgetPreview.tsx
+++ b/src/components/WidgetPreview.tsx
@@ -25,6 +25,8 @@ const WidgetPreview = ({content}: {content: string | undefined}) => {
     if (content) {
       const { index, content: extractedContent } = extractContent(content);
       setExtractedContent({ index, content: extractedContent });
+    } else {
+      setExtractedContent({ index: '', content: '' });
     }
   }, [content]);
 

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -65,9 +65,12 @@ const HomeScreen = ({navigation}: Props) => {
   };
 
   // 최신 날짜 찾기
-  const findLatestDate = (sermonList: Sermon[]): string => {
-    if (sermonList.length === 0) return '';
-    return [...new Set(sermonList.map(sermon => sermon.date))].sort().reverse()[0];
+  const findLatestSermon = (sermonList: Sermon[]): Sermon | null => {
+    if (sermonList.length === 0) return null;
+    // created_at 기준 내림차순 정렬 후 첫 번째 sermon의 date 반환
+    const latestSermon = [...sermonList].sort((a, b) => b.created_at.seconds - a.created_at.seconds)[0];
+    console.log('Latest sermon:', latestSermon);
+    return latestSermon;
   };
 
   // 로컬 데이터 로드
@@ -84,7 +87,7 @@ const HomeScreen = ({navigation}: Props) => {
         
         // 메타데이터의 최신 날짜 정보가 없으면 계산
         if (!currentMetadata.latestDate && parsedData.length > 0) {
-          const newLatestDate = findLatestDate(parsedData);
+          const newLatestDate = findLatestSermon(parsedData)?.date;
           
           if (newLatestDate) {
             await saveMetadata({
@@ -190,7 +193,9 @@ const HomeScreen = ({navigation}: Props) => {
       console.log('Saved merged data to local storage');
       
       // 가장 최신 날짜 찾기
-      const newLatestDate = findLatestDate(mergedSermons);
+      const latestSermon = findLatestSermon(mergedSermons);
+      console.log('Latest sermon:', latestSermon);
+      const newLatestDate = latestSermon?.date;
       if (newLatestDate) {
         console.log(`New latest date: ${newLatestDate}`);
         
@@ -205,19 +210,19 @@ const HomeScreen = ({navigation}: Props) => {
         console.log(`Updated metadata with latest date: ${newLatestDate}`);
         
         // 화면에 표시할 설교는 따로 저장 (가장 최신 설교)
-        const displaySermon = mergedSermons.filter(sermon => sermon.date === newLatestDate);
-        await AsyncStorage.setItem(DISPLAY_SERMON_KEY, JSON.stringify(displaySermon));        
-        console.log('Display sermon saved:', displaySermon);
+        setDisplaySermon(latestSermon);
+        await AsyncStorage.setItem(DISPLAY_SERMON_KEY, JSON.stringify(latestSermon));        
+        console.log('Display sermon saved:', latestSermon);
         
         // 위젯 업데이트
         try {
-          await WidgetUpdateModule.onSermonUpdated(JSON.stringify(displaySermon));
+          await WidgetUpdateModule.onSermonUpdated(JSON.stringify(latestSermon));
           console.log('Sermon data saved');
         } catch (error) {
           console.error('Failed to update widgets:', error);
         }
+        setSermons([...mergedSermons]);
       }
-      setSermons([...mergedSermons]);
     } catch (error) {
       console.error('Error fetching sermons:', error);
     } finally {
@@ -232,13 +237,6 @@ const HomeScreen = ({navigation}: Props) => {
     fetchDataFromServer();
   };
 
-  // 최신 날짜의 설교만 표시
-  const getLatestSermons = () => {
-    if (!latestDate || sermons.length === 0) return [];
-    
-    // 가장 최근 날짜를 가진 설교만 필터링
-    return sermons.filter(sermon => sermon.date === latestDate);
-  };
 
   // 제목 텍스트 처리 - 소괄호 부분을 줄바꿈
   const processTitleText = (title: string | undefined): string => {
@@ -265,26 +263,28 @@ const HomeScreen = ({navigation}: Props) => {
     console.log('Latest Sermon Date:', latestSermonDate.toISOString());
 
     // 최신 날짜가 1주일 전보다 이전이면 서버에서 데이터 요청
-    if (latestSermonDate < oneWeekAgo) {
+    if (latestSermonDate <= oneWeekAgo) {
       console.log('Fetching data from server due to outdated latest date');
       onRefresh();
     }
     return true;
   }
-
-  useEffect(() => {
-    AutoRequest();
-  }
-  , [latestDate]);
-
+  
   // 초기 데이터 로드
   useEffect(() => {
     loadLocalData();
   }, []);
 
   useEffect(() => {
+    AutoRequest();
+  }
+  , [latestDate]);
+
+
+  useEffect(() => {
     // 설교가 변경되면 보여줄 설교를 업데이트
-    setDisplaySermon(getLatestSermons()[0] || undefined);    
+    // console.log('sermons changed:', sermons);
+    setDisplaySermon(findLatestSermon(sermons) || undefined);    
   }, [sermons])
   
 
@@ -295,9 +295,7 @@ const HomeScreen = ({navigation}: Props) => {
         <View style={{ backgroundColor: 'transparent', flexDirection: 'row', width: 305, height: 30, marginBottom: 35, alignItems: 'center'}}>
           <Image source={require('../assets/image/20250416_meditation_icon.png')} style={{ backgroundColor: 'transparent', borderRadius: 15, width: 20, height: 20 }} />
           <Text style={{ color: '#49454F', fontSize: 20, fontFamily: "Pretendard-Medium", marginLeft: 8}}>묵상만개</Text>
-          {/* <Icon name="setting" size={20} color="#49454F" style={{ marginLeft: 'auto' }} /> */}
           <TouchableOpacity onPress={() => navigation.navigate('SettingsScreen', { setSermons, setLatestDate, setMetadata, setDisplaySermon, onRefresh })} style={{ marginLeft: 'auto'}}>
-            {/* <Image source={require('../assets/image/Settings.png')} style={{ backgroundColor: 'transparent', borderRadius: 15, width: 27, height: 27 }} /> */}
             <SvgIcon name="SettingButton" size={20} color='black'/>
           </TouchableOpacity>
         </View>
@@ -310,17 +308,6 @@ const HomeScreen = ({navigation}: Props) => {
         <View style={{ backgroundColor: 'transparent', width: 305, height: 300, justifyContent: 'center', alignItems: 'center' }}>
           <WidgetPreview content={displaySermon?.content} />
         </View>
-        {/* <View style={{ backgroundColor: 'transparent', width: 305, height: 38, flexDirection: 'row', justifyContent: 'flex-end', alignItems: 'center' }}>
-            <TouchableOpacity onPress={() => navigation.navigate('EditScreen', { sermon: displaySermon })}>
-            <ImageBackground
-              source={require('../assets/image/EditButton.png')}
-              style={{ width: 62, height: 38, borderRadius: 10, justifyContent: 'center', alignItems: 'center' }}
-              imageStyle={{ borderRadius: 10 }}
-            >
-              <Text style={{ color: 'white', fontSize: 20, fontFamily: "Pretendard-Bold", textAlign: 'center', letterSpacing: -1 }}>편집</Text>
-            </ImageBackground>
-            </TouchableOpacity>
-        </View> */}
       </View>
     </SafeAreaView>
   );

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -41,6 +41,7 @@ const SettingsScreen = ({navigation, route}: Props) => {
       route.params.setDisplaySermon(undefined);
       
       console.log('Local storage and metadata cleared');
+      route.params.onRefresh();
     } catch (error) {
       console.error('Error clearing local storage:', error);
     }

--- a/src/types/Sermon.ts
+++ b/src/types/Sermon.ts
@@ -6,8 +6,8 @@ export interface Sermon {
   date: string; // 설교 날짜 (YYYY-MM-DD)
   category?: string; // 설교 카테고리
   day_of_week?: string; // 요일 (예: "SUN")
-  created_at: number; // Firestore 타임스탬프 (초 단위)
-  updated_at: number; // Firestore 타임스탬프 (초 단위)
+  created_at: {seconds: number, nanoseconds: number}; // Firestore 타임스탬프 (초 단위)
+  updated_at: {seconds: number, nanoseconds: number}; // Firestore 타임스탬프 (초 단위)
 }
 
 // 메타데이터 타입 정의


### PR DESCRIPTION
# Pull Request

## 작업내용
<!-- Jira 이슈 링크를 포함하여 작업 내용을 설명해주세요 -->
- [SCRUM-51] 최신 말씀데이터가 아닌 이전 말씀 데이터가 나옴

## Jira 티켓
<!-- Jira 티켓 링크를 넣어주세요 -->
🔗 [SCRUM-51](https://blossom-scrum.atlassian.net/browse/SCRUM-51)

## 변경 사항
### 기능 추가
- 
- 

### 버그 수정
- 서버의 날짜 데이터가 잘못 저장된 경우가 자주 있어서 최신 말씀을 찾을 때 date 가 아닌 created_at.seconds 로 정렬하도록 함
- 이전 말씀 가져온 날로 부터 일주일째 되는날 fetch 하도록함
- 로컬 데이터 초기화시 다시 데이터 가져옴

### 리팩토링
- 
- 

## 테스트 방법
<!-- 테스트 방법을 상세히 설명해주세요 -->
1. Settings 에서 데이터 새로고침, 로컬 데이터 초기화 버튼 눌러보기
2. 위젯과 말씀 내용이 일치하는지 확인

## 스크린샷
<!-- UI 변경사항이 있는 경우 스크린샷을 첨부해주세요 -->
<!-- Before & After 형식으로 첨부하면 좋습니다 -->

## 체크리스트
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 console.log를 제거했나요?
- [ ] 테스트 코드를 작성했나요?
- [ ] 문서를 업데이트했나요?

## 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 첨부해주세요 -->
Closes # 