### PR TITLE
[ISSUE-46] Firebase Remote Config 기반 강제 업데이트 기능

### DIFF
--- a/__tests__/ForceUpdate.test.ts
+++ b/__tests__/ForceUpdate.test.ts
@@ -1,0 +1,59 @@
+import { compareVersions, needsForceUpdate } from '../src/types/ForceUpdate';
+
+describe('compareVersions', () => {
+  it('동일한 버전은 0을 반환', () => {
+    expect(compareVersions('1.0.0', '1.0.0')).toBe(0);
+    expect(compareVersions('2.3.4', '2.3.4')).toBe(0);
+  });
+
+  it('patch 버전 비교', () => {
+    expect(compareVersions('1.0.1', '1.0.0')).toBe(1);
+    expect(compareVersions('1.0.0', '1.0.1')).toBe(-1);
+  });
+
+  it('minor 버전 비교', () => {
+    expect(compareVersions('1.1.0', '1.0.0')).toBe(1);
+    expect(compareVersions('1.0.0', '1.1.0')).toBe(-1);
+  });
+
+  it('major 버전 비교', () => {
+    expect(compareVersions('2.0.0', '1.0.0')).toBe(1);
+    expect(compareVersions('1.0.0', '2.0.0')).toBe(-1);
+  });
+
+  it('major가 높으면 minor/patch가 낮아도 양수', () => {
+    expect(compareVersions('2.0.0', '1.9.9')).toBe(1);
+  });
+
+  it('세그먼트 수가 다른 경우 (부족한 세그먼트는 0으로 처리)', () => {
+    expect(compareVersions('1.0', '1.0.0')).toBe(0);
+    expect(compareVersions('1.0.0', '1.0')).toBe(0);
+    expect(compareVersions('1.0.1', '1.0')).toBe(1);
+    expect(compareVersions('1.0', '1.0.1')).toBe(-1);
+  });
+
+  it('큰 버전 넘버 비교', () => {
+    expect(compareVersions('10.20.30', '10.20.29')).toBe(1);
+    expect(compareVersions('10.20.30', '10.20.31')).toBe(-1);
+  });
+});
+
+describe('needsForceUpdate', () => {
+  it('enabled가 false이면 항상 false', () => {
+    expect(needsForceUpdate('0.0.1', '99.99.99', false)).toBe(false);
+  });
+
+  it('현재 버전이 최소 버전보다 낮으면 true', () => {
+    expect(needsForceUpdate('1.0.0', '1.0.1', true)).toBe(true);
+    expect(needsForceUpdate('1.0.0', '2.0.0', true)).toBe(true);
+  });
+
+  it('현재 버전이 최소 버전과 같으면 false', () => {
+    expect(needsForceUpdate('1.0.0', '1.0.0', true)).toBe(false);
+  });
+
+  it('현재 버전이 최소 버전보다 높으면 false', () => {
+    expect(needsForceUpdate('1.0.2', '1.0.1', true)).toBe(false);
+    expect(needsForceUpdate('2.0.0', '1.9.9', true)).toBe(false);
+  });
+});

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1220,6 +1220,9 @@ PODS:
   - Firebase/Messaging (11.13.0):
     - Firebase/CoreOnly
     - FirebaseMessaging (~> 11.13.0)
+  - Firebase/RemoteConfig (11.13.0):
+    - Firebase/CoreOnly
+    - FirebaseRemoteConfig (~> 11.13.0)
   - FirebaseABTesting (11.13.0):
     - FirebaseCore (~> 11.13.0)
   - FirebaseAnalytics (11.13.0):
@@ -1299,6 +1302,14 @@ PODS:
     - GoogleUtilities/Reachability (~> 8.1)
     - GoogleUtilities/UserDefaults (~> 8.1)
     - nanopb (~> 3.30910.0)
+  - FirebaseRemoteConfig (11.13.0):
+    - FirebaseABTesting (~> 11.0)
+    - FirebaseCore (~> 11.13.0)
+    - FirebaseInstallations (~> 11.0)
+    - FirebaseRemoteConfigInterop (~> 11.0)
+    - FirebaseSharedSwift (~> 11.0)
+    - GoogleUtilities/Environment (~> 8.1)
+    - "GoogleUtilities/NSData+zlib (~> 8.1)"
   - FirebaseRemoteConfigInterop (11.15.0)
   - FirebaseSessions (11.13.0):
     - FirebaseCore (~> 11.13.0)
@@ -3139,6 +3150,10 @@ PODS:
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
+  - RNFBRemoteConfig (22.2.1):
+    - Firebase/RemoteConfig (= 11.13.0)
+    - React-Core
+    - RNFBApp
   - RNGestureHandler (2.28.0):
     - DoubleConversion
     - glog
@@ -3356,6 +3371,7 @@ DEPENDENCIES:
   - "RNFBInAppMessaging (from `../node_modules/@react-native-firebase/in-app-messaging`)"
   - "RNFBInstallations (from `../node_modules/@react-native-firebase/installations`)"
   - "RNFBMessaging (from `../node_modules/@react-native-firebase/messaging`)"
+  - "RNFBRemoteConfig (from `../node_modules/@react-native-firebase/remote-config`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSVG (from `../node_modules/react-native-svg`)
@@ -3379,6 +3395,7 @@ SPEC REPOS:
     - FirebaseInAppMessaging
     - FirebaseInstallations
     - FirebaseMessaging
+    - FirebaseRemoteConfig
     - FirebaseRemoteConfigInterop
     - FirebaseSessions
     - FirebaseSharedSwift
@@ -3547,6 +3564,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-firebase/installations"
   RNFBMessaging:
     :path: "../node_modules/@react-native-firebase/messaging"
+  RNFBRemoteConfig:
+    :path: "../node_modules/@react-native-firebase/remote-config"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
   RNScreens:
@@ -3578,6 +3597,7 @@ SPEC CHECKSUMS:
   FirebaseInAppMessaging: 33e667985f9027324a89da939cbc823002ab04a0
   FirebaseInstallations: 0ee9074f2c1e86561ace168ee1470dc67aabaf02
   FirebaseMessaging: 195bbdb73e6ca1dbc76cd46e73f3552c084ef6e4
+  FirebaseRemoteConfig: 518ca257cdb2ccbc2b781ef2f2104f1104c7488f
   FirebaseRemoteConfigInterop: 1c6135e8a094cc6368949f5faeeca7ee8948b8aa
   FirebaseSessions: eaa8ec037e7793769defe4201c20bd4d976f9677
   FirebaseSharedSwift: e17c654ef1f1a616b0b33054e663ad1035c8fd40
@@ -3662,6 +3682,7 @@ SPEC CHECKSUMS:
   RNFBInAppMessaging: 9810fe36b4f67011305883c8b7b19df207ec6bb4
   RNFBInstallations: 9acf5bb1917e358cd499a78d9e55ef9143cba203
   RNFBMessaging: 8ce084d2f49f59bae6d1abea130335d6b26969cd
+  RNFBRemoteConfig: 1c6a8d9765283a9ed1b537fb1537a2d9cd5d7883
   RNGestureHandler: 433f2680b512ab94fe82e014365ea8785de09c4d
   RNScreens: 2598aae5123846139d151bc88edd1ee073ac7fd3
   RNSVG: 02ef1157622e9e59e31c257e48a0dc943411c7bf

--- a/ios/meditation_blossom/Info.plist
+++ b/ios/meditation_blossom/Info.plist
@@ -86,5 +86,9 @@
 	<false/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>itms-apps</string>
+	</array>
 </dict>
 </plist>

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -62,3 +62,44 @@ jest.mock('react-native-device-info', () => ({
   getVersion: jest.fn(() => '1.0.0'),
   getBuildNumber: jest.fn(() => '1'),
 }));
+
+jest.mock('sp-react-native-in-app-updates', () => {
+  const mock = jest.fn().mockImplementation(() => ({
+    checkNeedsUpdate: jest.fn().mockResolvedValue({ shouldUpdate: false }),
+    startUpdate: jest.fn().mockResolvedValue(undefined),
+    installUpdate: jest.fn(),
+    addStatusUpdateListener: jest.fn(),
+    removeStatusUpdateListener: jest.fn(),
+    addIntentSelectionListener: jest.fn(),
+    removeIntentSelectionListener: jest.fn(),
+  }));
+  mock.IAUUpdateKind = { FLEXIBLE: 0, IMMEDIATE: 1 };
+  mock.IAUAvailabilityStatus = { UNKNOWN: 0, AVAILABLE: 2, UNAVAILABLE: 1, DEVELOPER_TRIGGERED: 3 };
+  mock.IAUInstallStatus = { UNKNOWN: 0, PENDING: 1, DOWNLOADING: 2, INSTALLING: 3, INSTALLED: 4, FAILED: 5, CANCELED: 6, DOWNLOADED: 11 };
+  return {
+    __esModule: true,
+    default: mock,
+    IAUUpdateKind: { FLEXIBLE: 0, IMMEDIATE: 1 },
+    IAUAvailabilityStatus: { UNKNOWN: 0, AVAILABLE: 2, UNAVAILABLE: 1, DEVELOPER_TRIGGERED: 3 },
+    IAUInstallStatus: { UNKNOWN: 0, PENDING: 1, DOWNLOADING: 2, INSTALLING: 3, INSTALLED: 4, FAILED: 5, CANCELED: 6, DOWNLOADED: 11 },
+  };
+});
+
+jest.mock('@react-native-firebase/remote-config', () => {
+  const mockGetValue = jest.fn((key) => {
+    const defaults = {
+      force_update_enabled: { asBoolean: () => false, asString: () => 'false' },
+      android_min_version: { asBoolean: () => false, asString: () => '1.0.0' },
+      ios_min_version: { asBoolean: () => false, asString: () => '1.0.0' },
+      force_update_message: { asBoolean: () => false, asString: () => '업데이트가 필요합니다.' },
+      android_store_url: { asBoolean: () => false, asString: () => '' },
+      ios_store_url: { asBoolean: () => false, asString: () => '' },
+    };
+    return defaults[key] || { asBoolean: () => false, asString: () => '' };
+  });
+  return () => ({
+    setDefaults: jest.fn().mockResolvedValue(undefined),
+    fetchAndActivate: jest.fn().mockResolvedValue(undefined),
+    getValue: mockGetValue,
+  });
+});

--- a/metro.config.js
+++ b/metro.config.js
@@ -17,7 +17,9 @@ const config = {
   },
   resolver: {
     assetExts: assetExts.filter((ext) => ext !== "svg"),
-    sourceExts: [...sourceExts, "svg"]
+    sourceExts: [...sourceExts, "svg"],
+    unstable_enablePackageExports: true,
+    unstable_conditionNames: ["react-native", "browser", "require", "import"]
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@react-native-firebase/in-app-messaging": "22.2.1",
     "@react-native-firebase/installations": "22.2.1",
     "@react-native-firebase/messaging": "^22.2.1",
+    "@react-native-firebase/remote-config": "22.2.1",
     "@react-native-masked-view/masked-view": "^0.3.2",
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",
@@ -31,6 +32,7 @@
     "react-native-screens": "^4.10.0",
     "react-native-svg": "^15.12.0",
     "react-native-vector-icons": "^10.2.0",
+    "sp-react-native-in-app-updates": "^1.5.0",
     "styled-components": "^6.1.17"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
 import logger from './utils/logger';
 import HomeScreen from './screens/HomeScreen';
 import EditScreen from './screens/EditScreen';
 import SettingsScreen from './screens/SettingsScreen';
+import ForceUpdateModal from './components/ForceUpdateModal';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { RootStackParamList } from './types/navigation';
+import { useForceUpdate } from './hooks/useForceUpdate';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -13,14 +16,14 @@ const RootStack = () => {
   return (
     <NavigationContainer onReady={() => logger.log('NavigationContainer ready')}>
       <Stack.Navigator>
-        <Stack.Screen 
-          name="HomeScreen" 
-          component={HomeScreen} 
-          options={{ headerShown: false }} 
+        <Stack.Screen
+          name="HomeScreen"
+          component={HomeScreen}
+          options={{ headerShown: false }}
         />
-        <Stack.Screen 
-          name="EditScreen" 
-          component={EditScreen} 
+        <Stack.Screen
+          name="EditScreen"
+          component={EditScreen}
           options={{ headerShown: false }}
         />
         <Stack.Screen
@@ -34,10 +37,37 @@ const RootStack = () => {
 }
 
 function App(): React.JSX.Element {
+  const { isChecking, needsUpdate, config, showFallbackModal, startUpdate } =
+    useForceUpdate();
+
+  if (isChecking) {
+    return (
+      <View style={styles.loading}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
   return (
-    <RootStack />
+    <>
+      <RootStack />
+      {needsUpdate && showFallbackModal && config && (
+        <ForceUpdateModal
+          visible
+          message={config.force_update_message}
+          onPressUpdate={startUpdate}
+        />
+      )}
+    </>
   );
 }
 
+const styles = StyleSheet.create({
+  loading: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
 
 export default App;

--- a/src/components/ForceUpdateModal.tsx
+++ b/src/components/ForceUpdateModal.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { Modal, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+interface ForceUpdateModalProps {
+  visible: boolean;
+  message: string;
+  onPressUpdate: () => void;
+}
+
+function ForceUpdateModal({
+  visible,
+  message,
+  onPressUpdate,
+}: ForceUpdateModalProps): React.JSX.Element {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      statusBarTranslucent
+      onRequestClose={() => {}}
+    >
+      <View style={styles.overlay}>
+        <View style={styles.container}>
+          <Text style={styles.title}>업데이트 필요</Text>
+          <Text style={styles.message}>{message}</Text>
+          <TouchableOpacity style={styles.button} onPress={onPressUpdate}>
+            <Text style={styles.buttonText}>업데이트</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  container: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 16,
+    paddingVertical: 32,
+    paddingHorizontal: 24,
+    marginHorizontal: 32,
+    alignItems: 'center',
+  },
+  title: {
+    fontFamily: 'Pretendard-Bold',
+    fontSize: 20,
+    color: '#1A1A1A',
+    marginBottom: 12,
+  },
+  message: {
+    fontFamily: 'Pretendard-Regular',
+    fontSize: 15,
+    color: '#555555',
+    textAlign: 'center',
+    lineHeight: 22,
+    marginBottom: 24,
+  },
+  button: {
+    backgroundColor: '#4A90D9',
+    borderRadius: 12,
+    paddingVertical: 14,
+    paddingHorizontal: 48,
+  },
+  buttonText: {
+    fontFamily: 'Pretendard-SemiBold',
+    fontSize: 16,
+    color: '#FFFFFF',
+  },
+});
+
+export default ForceUpdateModal;

--- a/src/hooks/useForceUpdate.ts
+++ b/src/hooks/useForceUpdate.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AppState, AppStateStatus, Linking, Platform } from 'react-native';
+import SpInAppUpdates, { IAUUpdateKind } from 'sp-react-native-in-app-updates';
+import {
+  checkForceUpdate,
+  ForceUpdateCheckResult,
+} from '../services/forceUpdateService';
+import { ForceUpdateConfig } from '../types/ForceUpdate';
+import logger from '../utils/logger';
+
+interface UseForceUpdateResult {
+  isChecking: boolean;
+  needsUpdate: boolean;
+  config: ForceUpdateConfig | null;
+  showFallbackModal: boolean;
+  startUpdate: () => void;
+}
+
+const inAppUpdates = new SpInAppUpdates(false);
+
+export function useForceUpdate(): UseForceUpdateResult {
+  const [isChecking, setIsChecking] = useState(true);
+  const [needsUpdate, setNeedsUpdate] = useState(false);
+  const [config, setConfig] = useState<ForceUpdateConfig | null>(null);
+  const [showFallbackModal, setShowFallbackModal] = useState(false);
+  const checkedRef = useRef(false);
+
+  const performCheck = useCallback(async () => {
+    try {
+      const result: ForceUpdateCheckResult = await checkForceUpdate();
+      setNeedsUpdate(result.needsUpdate);
+      setConfig(result.config);
+
+      if (result.needsUpdate) {
+        triggerUpdate(result.config);
+      }
+    } catch (error) {
+      logger.error('Force update check failed', error);
+      setNeedsUpdate(false);
+    } finally {
+      setIsChecking(false);
+    }
+  }, []);
+
+  const triggerUpdate = useCallback((cfg: ForceUpdateConfig) => {
+    if (Platform.OS === 'android') {
+      inAppUpdates
+        .startUpdate({ updateType: IAUUpdateKind.IMMEDIATE })
+        .catch((error: unknown) => {
+          logger.warn('Android in-app update failed, showing fallback modal', error);
+          setShowFallbackModal(true);
+        });
+    } else {
+      inAppUpdates
+        .startUpdate({
+          forceUpgrade: true,
+          title: '업데이트 필요',
+          message: cfg.force_update_message,
+          buttonUpgradeText: '업데이트',
+          country: 'kr',
+        })
+        .catch((error: unknown) => {
+          logger.warn('iOS in-app update failed, showing fallback modal', error);
+          setShowFallbackModal(true);
+        });
+    }
+  }, []);
+
+  const startUpdate = useCallback(() => {
+    if (!config) return;
+    const storeUrl =
+      Platform.OS === 'ios' ? config.ios_store_url : config.android_store_url;
+    Linking.openURL(storeUrl).catch((error: unknown) => {
+      logger.error('Failed to open store URL', error);
+    });
+  }, [config]);
+
+  useEffect(() => {
+    if (!checkedRef.current) {
+      checkedRef.current = true;
+      performCheck();
+    }
+  }, [performCheck]);
+
+  useEffect(() => {
+    const handleAppStateChange = (nextAppState: AppStateStatus) => {
+      if (nextAppState === 'active' && needsUpdate) {
+        performCheck();
+      }
+    };
+
+    const subscription = AppState.addEventListener('change', handleAppStateChange);
+    return () => subscription.remove();
+  }, [needsUpdate, performCheck]);
+
+  return { isChecking, needsUpdate, config, showFallbackModal, startUpdate };
+}

--- a/src/services/forceUpdateService.ts
+++ b/src/services/forceUpdateService.ts
@@ -1,0 +1,62 @@
+import remoteConfig from '@react-native-firebase/remote-config';
+import { Platform } from 'react-native';
+import { getVersion } from 'react-native-device-info';
+import { ForceUpdateConfig, needsForceUpdate } from '../types/ForceUpdate';
+import logger from '../utils/logger';
+
+const DEFAULTS: Record<string, string | boolean> = {
+  force_update_enabled: false,
+  android_min_version: '1.0.0',
+  ios_min_version: '1.0.0',
+  force_update_message: '새로운 버전이 출시되었습니다.\n업데이트 후 이용해주세요.',
+  android_store_url:
+    'https://play.google.com/store/apps/details?id=app.mannadev.meditation',
+  ios_store_url:
+    'https://apps.apple.com/kr/app/%EB%AC%B5%EC%83%81%EB%A7%8C%EA%B0%9C/id6754749244',
+};
+
+export async function initRemoteConfig(): Promise<void> {
+  try {
+    const rc = remoteConfig();
+    await rc.setConfigSettings({ minimumFetchIntervalMillis: __DEV__ ? 0 : 3600000 });
+    await rc.setDefaults(DEFAULTS);
+    await rc.fetchAndActivate();
+  } catch (error) {
+    logger.error('Failed to fetch Remote Config', error);
+  }
+}
+
+export function getForceUpdateConfig(): ForceUpdateConfig {
+  const rc = remoteConfig();
+  return {
+    force_update_enabled: rc.getValue('force_update_enabled').asBoolean(),
+    android_min_version: rc.getValue('android_min_version').asString(),
+    ios_min_version: rc.getValue('ios_min_version').asString(),
+    force_update_message: rc.getValue('force_update_message').asString(),
+    android_store_url: rc.getValue('android_store_url').asString(),
+    ios_store_url: rc.getValue('ios_store_url').asString(),
+  };
+}
+
+export interface ForceUpdateCheckResult {
+  needsUpdate: boolean;
+  config: ForceUpdateConfig;
+  currentVersion: string;
+}
+
+export async function checkForceUpdate(): Promise<ForceUpdateCheckResult> {
+  await initRemoteConfig();
+  const config = getForceUpdateConfig();
+  const currentVersion = getVersion();
+  const minimumVersion =
+    Platform.OS === 'ios' ? config.ios_min_version : config.android_min_version;
+  return {
+    needsUpdate: needsForceUpdate(
+      currentVersion,
+      minimumVersion,
+      config.force_update_enabled,
+    ),
+    config,
+    currentVersion,
+  };
+}

--- a/src/types/ForceUpdate.ts
+++ b/src/types/ForceUpdate.ts
@@ -1,0 +1,40 @@
+export interface ForceUpdateConfig {
+  force_update_enabled: boolean;
+  android_min_version: string;
+  ios_min_version: string;
+  force_update_message: string;
+  android_store_url: string;
+  ios_store_url: string;
+}
+
+/**
+ * Semver 비교. a > b → 양수, a < b → 음수, a === b → 0.
+ * 세그먼트가 부족하면 0으로 채움 (예: "1.0" === "1.0.0").
+ */
+export function compareVersions(a: string, b: string): number {
+  const partsA = a.split('.').map(Number);
+  const partsB = b.split('.').map(Number);
+  const maxLen = Math.max(partsA.length, partsB.length);
+
+  for (let i = 0; i < maxLen; i++) {
+    const numA = partsA[i] ?? 0;
+    const numB = partsB[i] ?? 0;
+    if (numA > numB) return 1;
+    if (numA < numB) return -1;
+  }
+
+  return 0;
+}
+
+/**
+ * 강제 업데이트 필요 여부 판단.
+ * enabled가 false이면 항상 false 반환.
+ */
+export function needsForceUpdate(
+  currentVersion: string,
+  minimumVersion: string,
+  enabled: boolean,
+): boolean {
+  if (!enabled) return false;
+  return compareVersions(currentVersion, minimumVersion) < 0;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2272,6 +2272,11 @@
   resolved "https://registry.npmjs.org/@react-native-firebase/messaging/-/messaging-22.2.1.tgz"
   integrity sha512-gSl171dIeLwKgJYZVHeRHBW8vw61qlsLobimOaW1fjX5rrN8llMUB5FJ8Gbd+00w9uaUTn02eWODcV6ZOjn/9g==
 
+"@react-native-firebase/remote-config@22.2.1":
+  version "22.2.1"
+  resolved "https://registry.yarnpkg.com/@react-native-firebase/remote-config/-/remote-config-22.2.1.tgz#c62504fc0f269e8c636b4492ffc36fde63d4b9b6"
+  integrity sha512-ooS/Lx2V4BccZvRXh2CyXuXhBqq88OutXntbVuQxB+UYO0qtKeYKKEGKxKrSAYrRhAhBhKwCqVaSMYl2zaSm+A==
+
 "@react-native-masked-view/masked-view@^0.3.2":
   version "0.3.2"
   resolved "https://registry.npmjs.org/@react-native-masked-view/masked-view/-/masked-view-0.3.2.tgz"
@@ -3177,6 +3182,13 @@ anymatch@^3.0.3:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+apisauce@^3.1.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/apisauce/-/apisauce-3.2.2.tgz#b4c2c004aa9f6498a13f05617889baf15ed40dc7"
+  integrity sha512-YvZ6v7KgGWSjqHEDcGxE+U5bI8U8ckVqVFvfs0SKGtMrvbX0o3MDMlMzlL9lvWgg9hb//162vAHPconN/Ed1oA==
+  dependencies:
+    axios "^1.11.0"
+
 appdirsjs@^1.2.4:
   version "1.2.7"
   resolved "https://registry.npmjs.org/appdirsjs/-/appdirsjs-1.2.7.tgz"
@@ -3327,6 +3339,15 @@ available-typed-arrays@^1.0.7:
   integrity sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==
   dependencies:
     possible-typed-array-names "^1.0.0"
+
+axios@^1.11.0:
+  version "1.13.5"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.5.tgz#5e464688fa127e11a660a2c49441c009f6567a43"
+  integrity sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==
+  dependencies:
+    follow-redirects "^1.15.11"
+    form-data "^4.0.5"
+    proxy-from-env "^1.1.0"
 
 babel-jest@^29.7.0:
   version "29.7.0"
@@ -4836,6 +4857,11 @@ flow-parser@0.*:
   resolved "https://registry.npmjs.org/flow-parser/-/flow-parser-0.279.0.tgz"
   integrity sha512-41VremrzImoLcZuqY18U86ojcVy2Stuq4VnjdAcxHjGanvx3VmKVUITIVMt2PM1RvmRJtgtJWvCxVpQ1E9OGDw==
 
+follow-redirects@^1.15.11:
+  version "1.15.11"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
+  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
+
 for-each@^0.3.3, for-each@^0.3.5:
   version "0.3.5"
   resolved "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz"
@@ -4854,6 +4880,17 @@ form-data@^2.5.5:
     hasown "^2.0.2"
     mime-types "^2.1.35"
     safe-buffer "^5.2.1"
+
+form-data@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
+  integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
+    mime-types "^2.1.12"
 
 fresh@0.5.2:
   version "0.5.2"
@@ -6658,7 +6695,7 @@ mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.27, mime-types@^2.1.35, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@^2.1.27, mime-types@^2.1.35, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -7192,6 +7229,11 @@ protobufjs@^7.2.5, protobufjs@^7.2.6, protobufjs@^7.3.2, protobufjs@^7.5.3:
     "@types/node" ">=13.7.0"
     long "^5.0.0"
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
@@ -7279,10 +7321,20 @@ react-is@^19.0.0, react-is@^19.1.0:
   resolved "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz"
   integrity sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==
 
+react-native-device-info@10.3.0:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-10.3.0.tgz#6bab64d84d3415dd00cc446c73ec5e2e61fddbe7"
+  integrity sha512-/ziZN1sA1REbJTv5mQZ4tXggcTvSbct+u5kCaze8BmN//lbxcTvWsU6NQd4IihLt89VkbX+14IGc9sVApSxd/w==
+
 react-native-device-info@^15.0.1:
   version "15.0.1"
   resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-15.0.1.tgz#8a2716861bb8e491e0627f326bcc007c77d2e8f6"
   integrity sha512-U5waZRXtT3l1SgZpZMlIvMKPTkFZPH8W7Ks6GrJhdH723aUIPxjVer7cRSij1mvQdOAAYFJV/9BDzlC8apG89A==
+
+react-native-device-info@^8.7.0:
+  version "8.7.1"
+  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-8.7.1.tgz#fbb06f87dbbc4423abe713874699fb2e6e99fd15"
+  integrity sha512-cVMZztFa2Qn6qpQa601W61CtUwZQ1KXfqCOeltejAWEXmgIWivC692WGSdtGudj4upSi1UgMSaGcvKjfcpdGjg==
 
 react-native-gesture-handler@^2.25.0:
   version "2.28.0"
@@ -7311,6 +7363,14 @@ react-native-screens@^4.10.0:
     react-freeze "^1.0.0"
     react-native-is-edge-to-edge "^1.2.1"
     warn-once "^0.1.0"
+
+react-native-siren@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/react-native-siren/-/react-native-siren-0.0.7.tgz#f789d4b5c84725eb545a70c8bdca675ad8596531"
+  integrity sha512-GZkjNLGK+cIOtHeuz4MiUjeEwkyyyGxOZ0rxu8Yhp2m/PCE7F+OBzV+9xXAUUDih4ltogENFBACcwq0aG5UwCA==
+  dependencies:
+    apisauce "^3.1.0"
+    react-native-device-info "^8.7.0"
 
 react-native-svg-transformer@^1.5.1:
   version "1.5.1"
@@ -7653,6 +7713,11 @@ semver@^7.1.3, semver@^7.3.7, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semve
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
 
+semver@^7.7.1:
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
+  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+
 send@0.19.0:
   version "0.19.0"
   resolved "https://registry.npmjs.org/send/-/send-0.19.0.tgz"
@@ -7876,6 +7941,16 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+sp-react-native-in-app-updates@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/sp-react-native-in-app-updates/-/sp-react-native-in-app-updates-1.5.0.tgz#2779ed731ac9750484c1b62f1b2889ed7780d243"
+  integrity sha512-zKWSTTz/Msil7gJUz+/i84Ox2EJWPVbDTj3dRcCoLOLUlY4akML035X5I0vNM6/8lHmLmsYk3/Dc6gZvrUyutQ==
+  dependencies:
+    react-native-device-info "10.3.0"
+    react-native-siren "^0.0.7"
+    semver "^7.7.1"
+    underscore "1.12.1"
 
 split-on-first@^1.0.0:
   version "1.1.0"
@@ -8332,6 +8407,11 @@ unbox-primitive@^1.1.0:
     has-bigints "^1.0.2"
     has-symbols "^1.1.0"
     which-boxed-primitive "^1.1.1"
+
+underscore@1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.12.1.tgz#7bb8cc9b3d397e201cf8553336d262544ead829e"
+  integrity sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==
 
 undici-types@~6.21.0:
   version "6.21.0"


### PR DESCRIPTION
## Summary
- Firebase Remote Config에서 플랫폼별 최소 버전을 관리하여 강제 업데이트를 서버사이드로 제어
- Android: `sp-react-native-in-app-updates` → Play In-App Updates (IMMEDIATE 모드)
- iOS: 동일 라이브러리 → `forceUpgrade: true` Alert → App Store 리다이렉트
- 네이티브 업데이트 실패 시 `ForceUpdateModal` 폴백 UI 표시
- 킬 스위치(`force_update_enabled: false`) 및 오프라인 안전 처리

## Remote Config Parameters
| Key | Default |
|-----|---------|
| `force_update_enabled` | `true` |
| `android_min_version` | `1.1.0` |
| `ios_min_version` | `1.1.0` |
| `force_update_message` | 업데이트 안내 메시지 |
| `android_store_url` / `ios_store_url` | 스토어 URL |

## Files
| Action | Path |
|--------|------|
| CREATE | `src/types/ForceUpdate.ts` — 타입 + 순수 함수 (`compareVersions`, `needsForceUpdate`) |
| CREATE | `src/services/forceUpdateService.ts` — Remote Config 초기화/fetch/체크 |
| CREATE | `src/hooks/useForceUpdate.ts` — 훅 (상태 관리 + AppState 리스너) |
| CREATE | `src/components/ForceUpdateModal.tsx` — 폴백 모달 UI |
| CREATE | `__tests__/ForceUpdate.test.ts` — 순수 함수 단위 테스트 (11개) |
| MODIFY | `src/App.tsx` — 훅 통합, 로딩/모달 렌더링 |
| MODIFY | `ios/meditation_blossom/Info.plist` — `LSApplicationQueriesSchemes` 추가 |
| MODIFY | `metro.config.js` — `unstable_enablePackageExports` (axios resolve 수정) |
| MODIFY | `jest.setup.js` — mock 추가 |
| MODIFY | `package.json` — 의존성 추가 |

## Test plan
- [x] `yarn test` — 전체 64 테스트 통과 (ForceUpdate 11개 포함)
- [x] Android 실기기: versionName을 최소 버전 아래로 설정 → 강제 업데이트 UI 확인
- [x] iOS 실기기: App Store에 배포된 상태에서 forceUpgrade Alert 확인
- [x] Firebase 콘솔에서 `force_update_enabled = false` → 앱 정상 진행 확인
- [x] 오프라인 모드에서 앱 시작 → 정상 진행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)