### PR TITLE
[ISSUE-51] [FE] feat: 설정 화면 위젯 유튜브 이동 토글 추가

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -110,11 +110,11 @@ const HomeScreen = () => {
         </TouchableOpacity>
       </View>
       <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent}>
-        <Text style={styles.indexText}>{sermonContent.index}</Text>
         <Text style={styles.dateText}>{sermon?.date}</Text>
         <Text style={styles.titleText} numberOfLines={0}>
           {processTitleText(sermon?.title)}
         </Text>
+        <Text style={styles.indexText}>{sermonContent.index}</Text>
         <Text style={styles.contentText}>{sermonContent.content}</Text>
         <TouchableOpacity
           style={styles.youtubeLinkContainer}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -8,6 +8,7 @@ import {
   Platform,
   ScrollView,
   StyleSheet,
+  Switch,
   Text,
   TouchableOpacity,
   View,
@@ -27,6 +28,7 @@ const SettingsScreen = ({ navigation, route }: Props) => {
   const [showDeveloperMenu, setShowDeveloperMenu] = useState(false);
   const [tapCount, setTapCount] = useState(0);
   const [fcmToken, setFcmToken] = useState<string | null>(null);
+  const [youtubeLinkEnabled, setYoutubeLinkEnabled] = useState(false);
 
   const toggleDeveloperMenu = () => {
     const newTapCount = tapCount + 1;
@@ -63,6 +65,20 @@ const SettingsScreen = ({ navigation, route }: Props) => {
       logger.error('Error inspecting AsyncStorage:', JSON.stringify(error, null, 2));
     }
   };
+
+  useEffect(() => {
+    const loadYoutubeLinkSetting = async () => {
+      try {
+        if (WidgetUpdateModule) {
+          const enabled = await WidgetUpdateModule.getYoutubeLinkEnabled();
+          setYoutubeLinkEnabled(enabled);
+        }
+      } catch (error) {
+        logger.error('YouTube 링크 설정 불러오기 실패:', error);
+      }
+    };
+    loadYoutubeLinkSetting();
+  }, []);
 
   useEffect(() => {
     const getFCMToken = async () => {
@@ -119,6 +135,25 @@ const SettingsScreen = ({ navigation, route }: Props) => {
           contentContainerStyle={styles.scrollContent}
         >
           <View style={styles.topSection}>
+            {/* 위젯 YouTube 링크 토글 */}
+            <View style={styles.toggleRow}>
+              <Text style={styles.toggleLabel}>위젯을 눌렀을 때 유튜브로 이동</Text>
+              <Switch
+                value={youtubeLinkEnabled}
+                onValueChange={async (value) => {
+                  setYoutubeLinkEnabled(value);
+                  try {
+                    if (WidgetUpdateModule) {
+                      await WidgetUpdateModule.setYoutubeLinkEnabled(value);
+                    }
+                  } catch (error) {
+                    logger.error('YouTube 링크 설정 저장 실패:', error);
+                    setYoutubeLinkEnabled(!value);
+                  }
+                }}
+              />
+            </View>
+
             {/* 제목 영역 */}
             <TouchableOpacity onPress={toggleDeveloperMenu} style={styles.sectionTitle}>
               <Text style={styles.sectionTitleText}>앱 관리</Text>
@@ -172,7 +207,7 @@ const SettingsScreen = ({ navigation, route }: Props) => {
             <Text style={styles.aboutTitle}>About this app</Text>
             <View style={styles.aboutContent}>
               <Text style={styles.aboutText}>
-                묵상만개{'\n'}Meditation Blossom
+                묵상만개{'\n'}Meditation Blossom v2.0
               </Text>
               <TouchableOpacity
                 onPress={() => Linking.openURL('https://manna.or.kr/somoim/157228/')}
@@ -257,6 +292,19 @@ const styles = StyleSheet.create({
   },
   topSection: {
     alignItems: 'center',
+  },
+  toggleRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    width: 305,
+    marginBottom: 20,
+  },
+  toggleLabel: {
+    color: '#49454F',
+    fontSize: 14,
+    fontFamily: 'Pretendard-Regular',
+    flex: 1,
   },
   sectionTitle: {
     backgroundColor: 'transparent',

--- a/src/types/WidgetUpdateModule.ts
+++ b/src/types/WidgetUpdateModule.ts
@@ -4,6 +4,8 @@ interface WidgetUpdateModuleInterface {
   onSermonUpdated(sermonData: string): Promise<boolean>;
   onClear(): Promise<void>;
   getAppGroupData(key: string): Promise<string | null>;
+  setYoutubeLinkEnabled(enabled: boolean): Promise<void>;
+  getYoutubeLinkEnabled(): Promise<boolean>;
 }
 
 const { WidgetUpdateModule } = NativeModules;


### PR DESCRIPTION
## 작업내용
- [ISSUE-51] 설정 화면에 '위젯을 눌렀을 때 유튜브로 이동' 토글 추가 및 네이티브 브릿지 연동
#51 

## 변경 사항
### 기능 추가
- 설정 화면 최상단에 '위젯을 눌렀을 때 유튜브로 이동' 토글 스위치 추가
- 앱 실행 시 `getYoutubeLinkEnabled()`로 저장된 설정값 불러오기
- 토글 변경 시 `setYoutubeLinkEnabled()`로 네이티브 저장소에 저장, 실패 시 상태 롤백

### 리팩토링
- `WidgetUpdateModule.ts`에 `setYoutubeLinkEnabled` / `getYoutubeLinkEnabled` 타입 선언 추가
- About this app v2.0 업데이트

## 테스트 방법
1. 설정 화면 진입 시 최상단에 토글이 표시되는지 확인
2. 토글 on/off 시 상태가 유지되는지 확인 (앱 재시작 후 — 네이티브 구현 완료 후 검증 가능)
3. 네이티브 미구현 상태에서 토글 조작 시 앱이 에러 로그만 출력되는지 확인
4. 주일말씀 탭에서 말씀 장절이 제목 아래, 본문 위에 표시되는지 확인

## 스크린샷

<table>
  <tr>
    <td><img width="250" alt="before" src="https://github.com/user-attachments/assets/f4017584-71f0-4adc-86b7-c76c35424a24" /></td>
    <td><img width="250" alt="after" src="https://github.com/user-attachments/assets/a3d51f64-02cc-4958-be15-7324529743d8" /></td>
  </tr>
</table>

## 관련 이슈
- Closes #51
- 네이티브 구현 의존: #56 (Android), #60 (iOS)