### PR TITLE
[HOTFIX] chore: add .claude/worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ yarn-error.log
 # Private (do not commit)
 firebase-service-account.json
 firebase-debug.log
+
+# claude worktrees
+.claude/worktrees/


### PR DESCRIPTION
## Summary
- `.claude/worktrees/` 디렉토리를 `.gitignore`에 추가 (로컬 개발 도구 산출물)

## Test plan
- [x] `git status`에서 `.claude/worktrees/` 가 untracked로 표시되지 않는지 확인