### PR TITLE
[ISSUE-52] 주일말씀 데이터 로딩 리팩토링

### DIFF
--- a/__tests__/useSermonData.test.ts
+++ b/__tests__/useSermonData.test.ts
@@ -1,0 +1,148 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { useSermonData } from '../src/hooks/useSermonData';
+import * as sermonService from '../src/services/sermonService';
+
+jest.mock('../src/services/sermonService', () => ({
+  fetchLatestSermonFromAsyncStorage: jest.fn(),
+  fetchLatestSermonFromServer: jest.fn(),
+}));
+
+jest.mock('../src/utils/logger', () => ({
+  __esModule: true,
+  default: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const mockFetchFromAsyncStorage = sermonService.fetchLatestSermonFromAsyncStorage as jest.Mock;
+const mockFetchFromServer = sermonService.fetchLatestSermonFromServer as jest.Mock;
+
+const mockSermon = {
+  id: 'test-1',
+  title: '테스트 설교',
+  content: '설교 내용',
+  date: '2025-04-13',
+  day_of_week: 'SUN',
+  created_at: { seconds: 0, nanoseconds: 0 },
+  updated_at: { seconds: 0, nanoseconds: 0 },
+};
+
+describe('useSermonData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('초기 상태', () => {
+    it('isLoading true, sermon null, error null로 시작', () => {
+      mockFetchFromAsyncStorage.mockResolvedValue(null);
+      const { result } = renderHook(() => useSermonData());
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.sermon).toBeNull();
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe('loadLocalData', () => {
+    it('AsyncStorage에 값 있으면 sermon 세팅됨', async () => {
+      mockFetchFromAsyncStorage.mockResolvedValue(mockSermon);
+      const { result } = renderHook(() => useSermonData());
+
+      await act(async () => {
+        await result.current.loadLocalData();
+      });
+
+      expect(result.current.sermon).toEqual(mockSermon);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    it('AsyncStorage 비어있으면 sermon null, isLoading false', async () => {
+      mockFetchFromAsyncStorage.mockResolvedValue(null);
+      const { result } = renderHook(() => useSermonData());
+
+      await act(async () => {
+        await result.current.loadLocalData();
+      });
+
+      expect(result.current.sermon).toBeNull();
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('AsyncStorage 에러 시 error 상태 세팅됨', async () => {
+      mockFetchFromAsyncStorage.mockRejectedValue(new Error('storage fail'));
+      const { result } = renderHook(() => useSermonData());
+
+      await act(async () => {
+        await result.current.loadLocalData();
+      });
+
+      expect(result.current.error).toBe('storage fail');
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('AsyncStorage 에러 시 sermon은 null 유지됨', async () => {
+      mockFetchFromAsyncStorage.mockRejectedValue(new Error('storage fail'));
+      const { result } = renderHook(() => useSermonData());
+
+      await act(async () => {
+        await result.current.loadLocalData();
+      });
+
+      expect(result.current.sermon).toBeNull();
+    });
+  });
+
+  describe('fetchFromServer', () => {
+    it('서버에서 데이터 오면 sermon 세팅됨', async () => {
+      mockFetchFromServer.mockResolvedValue(mockSermon);
+      const { result } = renderHook(() => useSermonData());
+
+      await act(async () => {
+        await result.current.fetchFromServer();
+      });
+
+      expect(result.current.sermon).toEqual(mockSermon);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    it('서버가 null 반환하면 기존 sermon 유지됨', async () => {
+      mockFetchFromAsyncStorage.mockResolvedValue(mockSermon);
+      mockFetchFromServer.mockResolvedValue(null);
+      const { result } = renderHook(() => useSermonData());
+
+      await act(async () => {
+        await result.current.loadLocalData();
+      });
+      await act(async () => {
+        await result.current.fetchFromServer();
+      });
+
+      expect(result.current.sermon).toEqual(mockSermon);
+    });
+
+    it('서버 에러 시 error 상태 세팅됨', async () => {
+      mockFetchFromServer.mockRejectedValue(new Error('network error'));
+      const { result } = renderHook(() => useSermonData());
+
+      await act(async () => {
+        await result.current.fetchFromServer();
+      });
+
+      expect(result.current.error).toBe('network error');
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe('onRefresh', () => {
+    it('onRefresh 호출 시 fetchFromServer 실행됨', async () => {
+      mockFetchFromServer.mockResolvedValue(mockSermon);
+      const { result } = renderHook(() => useSermonData());
+
+      await act(async () => {
+        await result.current.onRefresh();
+      });
+
+      expect(mockFetchFromServer).toHaveBeenCalledTimes(1);
+      expect(result.current.sermon).toEqual(mockSermon);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "jest": "^29.7.0",
     "prettier": "3.5.3",
     "react-native-svg-transformer": "^1.5.1",
+    "react-test-renderer": "19.0.0",
     "typescript": "^5.8.2"
   },
   "engines": {

--- a/src/hooks/useAppGroupSync.ts
+++ b/src/hooks/useAppGroupSync.ts
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useRef } from 'react';
-import { AppState, Platform } from 'react-native';
-import { APP_GROUP_DISPLAY_SERMON_KEY, APP_GROUP_POLL_INTERVAL_MS } from '../constants';
+import { useCallback } from 'react';
+import { Platform } from 'react-native';
+import { APP_GROUP_DISPLAY_SERMON_KEY } from '../constants';
 import { readAppGroupData, syncAppGroupToAsyncStorage } from '../services/sermonService';
 import logger from '../utils/logger';
 
@@ -9,9 +9,10 @@ interface UseAppGroupSyncOptions {
   enabled: boolean;
 }
 
-export function useAppGroupSync({ onDataSynced, enabled }: UseAppGroupSyncOptions) {
-  const lastSyncedSignatureRef = useRef<string | null>(null);
-
+// iOS 앱 완전 종료 후 재시작 시 App Group → AsyncStorage 동기화 전용
+// NotificationService(Extension)가 sandbox 제약으로 AsyncStorage 직접 저장 불가하므로
+// 앱 재시작 1회 실행만 유지. 포그라운드/백그라운드 FCM 수신은 AppDelegate.mm이 직접 저장.
+export function useAppGroupSync({ onDataSynced: _onDataSynced, enabled: _enabled }: UseAppGroupSyncOptions) {
   const performInitialSync = useCallback(async () => {
     if (Platform.OS !== 'ios') return;
 
@@ -19,59 +20,11 @@ export function useAppGroupSync({ onDataSynced, enabled }: UseAppGroupSyncOption
       const appGroupData = await readAppGroupData(APP_GROUP_DISPLAY_SERMON_KEY);
       if (!appGroupData) return;
 
-      const newSig = await syncAppGroupToAsyncStorage(appGroupData, null);
-      lastSyncedSignatureRef.current = newSig;
+      await syncAppGroupToAsyncStorage(appGroupData, null);
     } catch (error) {
       logger.error('Error during initial App Group sync:', error);
     }
   }, []);
-
-  // AppState listener + periodic polling
-  useEffect(() => {
-    if (Platform.OS !== 'ios' || !enabled) return;
-
-    const syncFromAppGroup = async () => {
-      try {
-        const appGroupData = await readAppGroupData(APP_GROUP_DISPLAY_SERMON_KEY);
-        if (!appGroupData) return;
-
-        const newSig = await syncAppGroupToAsyncStorage(
-          appGroupData,
-          lastSyncedSignatureRef.current,
-        );
-        if (newSig) {
-          lastSyncedSignatureRef.current = newSig;
-          await onDataSynced();
-        }
-      } catch (error) {
-        logger.error('Error syncing App Group data:', error);
-      }
-    };
-
-    // Sync on foreground transitions
-    const subscription = AppState.addEventListener('change', (nextAppState) => {
-      if (nextAppState === 'active') {
-        syncFromAppGroup();
-      }
-    });
-
-    // If already active, sync now
-    if (AppState.currentState === 'active') {
-      syncFromAppGroup();
-    }
-
-    // Periodic polling (5s)
-    const intervalId = setInterval(() => {
-      if (AppState.currentState === 'active') {
-        syncFromAppGroup();
-      }
-    }, APP_GROUP_POLL_INTERVAL_MS);
-
-    return () => {
-      subscription.remove();
-      clearInterval(intervalId);
-    };
-  }, [enabled, onDataSynced]);
 
   return { performInitialSync };
 }

--- a/src/hooks/useSermonData.ts
+++ b/src/hooks/useSermonData.ts
@@ -1,8 +1,7 @@
 import { useCallback, useState } from 'react';
-import { compareSermon, Sermon } from '../types/Sermon';
+import { Sermon } from '../types/Sermon';
 import {
   fetchLatestSermonFromAsyncStorage,
-  fetchLatestSermonFromCache,
   fetchLatestSermonFromServer,
 } from '../services/sermonService';
 import logger from '../utils/logger';
@@ -24,24 +23,9 @@ export function useSermonData(): UseSermonDataReturn {
 
   const loadLocalData = useCallback(async (): Promise<Sermon | null> => {
     try {
-      const [firestoreCache, asyncStorageCache] = await Promise.all([
-        fetchLatestSermonFromCache(),
-        fetchLatestSermonFromAsyncStorage(),
-      ]);
+      const selected = await fetchLatestSermonFromAsyncStorage();
 
-      logger.log(
-        'Data sources:',
-        firestoreCache ? `Firestore(${firestoreCache.date})` : 'Firestore(null)',
-        asyncStorageCache ? `AsyncStorage(${asyncStorageCache.date})` : 'AsyncStorage(null)',
-      );
-
-      if (!firestoreCache && !asyncStorageCache) {
-        setSermon(null);
-        return null;
-      }
-
-      const result = compareSermon(firestoreCache, asyncStorageCache);
-      const selected = result >= 0 ? firestoreCache : asyncStorageCache;
+      logger.log('AsyncStorage sermon:', selected ? selected.date : 'null');
 
       setSermon(selected);
       setError(null);

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -111,7 +111,7 @@ const HomeScreen = () => {
           <SvgIcon name="SettingButton" size={20} color="black" />
         </TouchableOpacity>
       </View>
-      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent}>
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
         <Text style={styles.dateText}>{sermon?.date}</Text>
         <Text style={styles.titleText} numberOfLines={0}>
           {processTitleText(sermon?.title)}

--- a/src/services/sermonService.ts
+++ b/src/services/sermonService.ts
@@ -1,7 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   collection,
-  getDocsFromCache,
   getDocsFromServer,
   getFirestore,
   limit,
@@ -20,22 +19,6 @@ import {
 import WidgetUpdateModule from '../types/WidgetUpdateModule';
 import logger from '../utils/logger';
 import { normalizeJsonString } from '../utils/normalize';
-
-export async function fetchLatestSermonFromCache(): Promise<Sermon | null> {
-  try {
-    const db = getFirestore();
-    const q = query(
-      collection(db, 'sermons'),
-      orderBy('date', 'desc'),
-      limit(1),
-    );
-    const snapshot = await getDocsFromCache(q);
-    return snapshot.empty ? null : await firestoreDocToSermon(snapshot.docs[0]);
-  } catch (error) {
-    logger.error('Failed to load sermon from Firestore cache', error);
-    return null;
-  }
-}
 
 export async function fetchLatestSermonFromAsyncStorage(): Promise<Sermon | null> {
   try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7405,6 +7405,11 @@ react-is@^18.0.0, react-is@^18.3.1:
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
+react-is@^19.0.0:
+  version "19.2.5"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.2.5.tgz#7e7b54143e9313fed787b23fd4295d5a23872ad9"
+  integrity sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==
+
 react-is@^19.1.0:
   version "19.1.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz"
@@ -7546,6 +7551,14 @@ react-refresh@^0.14.0:
   version "0.14.2"
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz"
   integrity sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==
+
+react-test-renderer@19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-19.0.0.tgz#ca6fa322c58d4bfa34635788fe242a8c3daa4c7d"
+  integrity sha512-oX5u9rOQlHzqrE/64CNr0HB0uWxkCQmZNSfozlYvwE71TLVgeZxVf0IjouGEr1v7r1kcDifdAJBeOhdhxsG/DA==
+  dependencies:
+    react-is "^19.0.0"
+    scheduler "^0.25.0"
 
 react@19.0.0:
   version "19.0.0"
@@ -7786,7 +7799,7 @@ safe-regex-test@^1.1.0:
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-scheduler@0.25.0:
+scheduler@0.25.0, scheduler@^0.25.0:
   version "0.25.0"
   resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz"
   integrity sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==


### PR DESCRIPTION
## 작업내용
주일말씀 데이터 로딩 흐름을 Firestore 캐시 + AsyncStorage 이중 소스에서 AsyncStorage 단일 소스로 단순화합니다.

## 변경 사항
### 리팩토링
- `useSermonData`: `fetchLatestSermonFromCache()` / `compareSermon()` 제거, `fetchLatestSermonFromAsyncStorage()` 단일 소스로 통일
- `sermonService`: `fetchLatestSermonFromCache()` 함수 제거
- `useAppGroupSync`: AppState 리스너 및 5초 폴링 제거, 앱 재시작 시 1회 실행(`performInitialSync`)만 유지

### 동작 수정
- HomeScreen ScrollView 스크롤바 숨김

## 테스트 방법
1. 앱 최초 설치 시 AsyncStorage 비어있으면 Firestore에서 fetch 후 화면 표시 확인
2. FCM 수신 후 앱 진입 시 AsyncStorage 데이터 즉시 표시 확인