### PR TITLE
[HOTFIX] fix: meditation_questions JSON 배열 파싱으로 수정

### DIFF
--- a/__tests__/QT.test.ts
+++ b/__tests__/QT.test.ts
@@ -49,10 +49,10 @@ describe('fcmDataToQt', () => {
   it('매핑: meditation_questions 있으면 그대로 전달됨', () => {
     const raw: QTRaw = {
       id: '1', title: 'T', series_title: '', content: 'C', date: '2026-04-17',
-      meditation_questions: '오늘 말씀에서 가장 마음에 닿은 구절은?\n이 말씀을 삶에 어떻게 적용할 수 있을까?',
+      meditation_questions: '["오늘 말씀에서 가장 마음에 닿은 구절은?","이 말씀을 삶에 어떻게 적용할 수 있을까?"]',
     };
     expect(fcmDataToQt(raw).meditation_questions).toBe(
-      '오늘 말씀에서 가장 마음에 닿은 구절은?\n이 말씀을 삶에 어떻게 적용할 수 있을까?',
+      '["오늘 말씀에서 가장 마음에 닿은 구절은?","이 말씀을 삶에 어떻게 적용할 수 있을까?"]',
     );
   });
 

--- a/src/screens/DailyMannaScreen.tsx
+++ b/src/screens/DailyMannaScreen.tsx
@@ -41,7 +41,12 @@ const DailyMannaScreen = () => {
 
   const meditationQuestions = useMemo(() => {
     if (!qt?.meditation_questions) return [];
-    return qt.meditation_questions.split('\n').filter(q => q.trim());
+    try {
+      const parsed = JSON.parse(qt.meditation_questions);
+      return Array.isArray(parsed) ? parsed.filter((q: string) => q.trim()) : [];
+    } catch {
+      return [];
+    }
   }, [qt?.meditation_questions]);
 
   const targetYoutubeUrl = qt?.video_url || DAILY_MANNA_CHANNEL_URL;

--- a/src/screens/DailyMannaScreen.tsx
+++ b/src/screens/DailyMannaScreen.tsx
@@ -233,6 +233,7 @@ const styles = StyleSheet.create({
     color: '#49454F',
     fontSize: 16,
     fontFamily: 'Pretendard-SemiBold',
+    lineHeight: 26,
   },
   questionText: {
     flex: 1,


### PR DESCRIPTION
## Summary
- FCM 스펙(docs/fcm-events/qt-events.md) 확인 결과 `meditation_questions`는 JSON 배열 문자열로 전달됨
- 기존 `split('\n')` → `JSON.parse()` 로 수정
- 테스트 케이스도 JSON 배열 형식으로 업데이트