### PR TITLE
[HOTFIX] fix: meditation_questions 파싱 실패 시 에러 로깅 추가

### DIFF
--- a/src/screens/DailyMannaScreen.tsx
+++ b/src/screens/DailyMannaScreen.tsx
@@ -44,7 +44,8 @@ const DailyMannaScreen = () => {
     try {
       const parsed = JSON.parse(qt.meditation_questions);
       return Array.isArray(parsed) ? parsed.filter((q: string) => q.trim()) : [];
-    } catch {
+    } catch (e) {
+      logger.error('DailyMannaScreen: meditation_questions 파싱 실패', e);
       return [];
     }
   }, [qt?.meditation_questions]);


### PR DESCRIPTION
catch 블록에서 에러를 무시하지 않도록 logger.error 추가 (CLAUDE.md 규칙 준수)

https://claude.ai/code/session_01Ssy4Fv8GnxPg3eZRjw14BB