### PR TITLE
[ISSUE-50] fix: 매일만나 묵상질문 매핑

### DIFF
--- a/__tests__/QT.test.ts
+++ b/__tests__/QT.test.ts
@@ -118,4 +118,15 @@ describe('firestoreDocToQt', () => {
     const result = await firestoreDocToQt(doc);
     expect(result.content).toBe('');
   });
+
+  it('Firestore array를 JSON 문자열로 변환', async () => {
+    const doc = makeDoc({
+      title: 'T', series_title: 'Daily', date: '2026-04-17',
+      meditation_questions: ['오늘 말씀에서 가장 마음에 와닿는 구절은?', '이 말씀을 삶에 어떻게 적용할 수 있을까?'],
+    });
+    const result = await firestoreDocToQt(doc);
+    expect(result.meditation_questions).toBe(
+      '["오늘 말씀에서 가장 마음에 와닿는 구절은?","이 말씀을 삶에 어떻게 적용할 수 있을까?"]',
+    );
+  });
 });

--- a/src/screens/DailyMannaScreen.tsx
+++ b/src/screens/DailyMannaScreen.tsx
@@ -44,7 +44,8 @@ const DailyMannaScreen = () => {
     try {
       const parsed = JSON.parse(qt.meditation_questions);
       return Array.isArray(parsed) ? parsed.filter((q: string) => q.trim()) : [];
-    } catch {
+    } catch (e) {
+      logger.error('DailyMannaScreen: meditation_questions 파싱 실패', e instanceof Error ? e.message : String(e));
       return [];
     }
   }, [qt?.meditation_questions]);
@@ -127,7 +128,7 @@ const DailyMannaScreen = () => {
             {meditationQuestions.map((question, index) => (
               <View key={index} style={styles.questionCard}>
                 <Text style={styles.questionNumber}>
-                  {index === 0 ? '❶' : index === 1 ? '❷' : `${index + 1}.`}
+                  {index === 0 ? '•' : ['❶','❷','❸','❹','❺'][index - 1] ?? `${index}.`}
                 </Text>
                 <Text style={styles.questionText}>{question}</Text>
               </View>

--- a/src/types/QT.ts
+++ b/src/types/QT.ts
@@ -85,6 +85,9 @@ export const firestoreDocToQt = async (
     date: data.date || new Date().toISOString().split('T')[0],
     day_of_week: data.day_of_week || '',
     video_url: data.video_url,
+    meditation_questions: data.meditation_questions
+      ? JSON.stringify(data.meditation_questions)
+      : undefined,
     created_at: data.created_at || { seconds: 0, nanoseconds: 0 },
     updated_at: data.updated_at || { seconds: 0, nanoseconds: 0 },
   };


### PR DESCRIPTION
## Summary

앱 시작 시 AsyncStorage가 비어있으면 Firebase에서 직접 가져오는 경로에서
묵상질문(`meditation_questions`)이 누락되어 있었습니다.

- `firestoreDocToQt()`에 `meditation_questions` 필드 매핑 추가
- 묵상질문 번호 스타일 수정 (첫 번째 항목 • , 이후 ❶❷❸❹❺)


<img width="350" alt="image" src="https://github.com/user-attachments/assets/85ace298-fc1b-4fd1-8a26-7e6f00aee8d8" />
