### PR TITLE
[ISSUE-89] fix: resolveTopic 수정 — 토큰 전송 시 FCM 메시지 무시되는 버그

### DIFF
--- a/android/app/src/main/java/app/mannadev/meditation/service/MyFirebaseMessagingService.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/service/MyFirebaseMessagingService.kt
@@ -81,11 +81,16 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
     }
 
     /** Extracts topic name from `from` ("/topics/NAME") or `data.topic`. Returns null if neither resolves,
-     *  and in DEBUG=false drops any `*_test` topic. */
+     *  and in DEBUG=false drops any `*_test` topic.
+     *  topic 메시지: from = "/topics/NAME" → removePrefix 로 NAME 추출
+     *  token 메시지: from = FCM 발신자ID(숫자) → data["topic"] 로 폴백 */
     private fun resolveTopic(message: RemoteMessage): String? {
-        val fromTopic = message.from?.removePrefix("/topics/")
-        val dataTopic = message.data[KEY_TOPIC]
-        val candidate = fromTopic ?: dataTopic ?: return null
+        val from = message.from
+        val candidate = if (from != null && from.startsWith("/topics/")) {
+            from.removePrefix("/topics/")
+        } else {
+            message.data[KEY_TOPIC]
+        } ?: return null
         if (!BuildConfig.DEBUG && candidate.endsWith("_test")) return null
         return candidate
     }


### PR DESCRIPTION
토큰 전송 시 message.from이 FCM 발신자 ID(숫자)로 채워져
removePrefix("/topics/")가 non-null을 반환, dataTopic 폴백이 평가되지 않아 silent drop되는 문제를 수정

https://github.com/orgs/MannaDevelopers/projects/1/views/1?filterQuery=&pane=issue&itemId=181646315&issue=MannaDevelopers%7Cmeditation_blossom_frontend%7C89