### PR TITLE
[ISSUE-95] 설정화면 새로고침 버튼 로직 완성

### DIFF
--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -28,7 +28,7 @@ const SharedHeader = () => {
       />
       <Text style={styles.appTitle}>묵상만개</Text>
       <TouchableOpacity
-        onPress={() => navigation.navigate('SettingsScreen', {})}
+        onPress={() => navigation.navigate('SettingsScreen')}
         style={styles.settingsButton}
       >
         <SvgIcon name="SettingButton" size={20} color="black" />

--- a/src/screens/DailyMannaScreen.tsx
+++ b/src/screens/DailyMannaScreen.tsx
@@ -11,6 +11,7 @@ import {
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useFocusEffect } from '@react-navigation/native';
 import SvgIcon from '../components/SvgIcon';
 import { useQtData } from '../hooks/useQtData';
 import { useQtFCMListener } from '../hooks/useQtFCMListener';
@@ -26,9 +27,20 @@ const DAILY_MANNA_CHANNEL_URL = 'https://www.youtube.com/@만나';
 const DailyMannaScreen = () => {
   const { qt, isLoading, setIsLoading, error, loadLocalData, fetchFromServer, onRefresh } =
     useQtData();
+  const isInitialMount = useRef(true);
 
   useQtWidgetSync(qt);
   useQtFCMListener(loadLocalData);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (isInitialMount.current) {
+        isInitialMount.current = false;
+        return;
+      }
+      loadLocalData();
+    }, [loadLocalData]),
+  );
 
   const qtContent = useMemo(
     () => (qt?.content ? extractContent(qt.content) : { index: '', content: '' }),

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -12,6 +12,7 @@ import {
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useFocusEffect } from '@react-navigation/native';
 import { extractContent } from '../utils/sermonParser';
 import SvgIcon from '../components/SvgIcon';
 import { BRIDGE_INIT_DELAY_MS } from '../constants';
@@ -29,6 +30,7 @@ const SUNDAY_SERMON_YOUTUBE_URL = 'https://www.youtube.com/@만나';
 const HomeScreen = () => {
   const { sermon, isLoading, setIsLoading, error, loadLocalData, fetchFromServer, onRefresh } =
     useSermonData();
+  const isInitialMount = useRef(true);
 
   const sermonContent = useMemo(
     () => (sermon?.content ? extractContent(sermon.content) : { index: '', content: '' }),
@@ -42,6 +44,16 @@ const HomeScreen = () => {
 
   useWidgetSync(sermon);
   useFCMListener(loadLocalData);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (isInitialMount.current) {
+        isInitialMount.current = false;
+        return;
+      }
+      loadLocalData();
+    }, [loadLocalData]),
+  );
 
   const targetYoutubeUrl = sermon?.video_url || SUNDAY_SERMON_YOUTUBE_URL;
   const hasLoggedScroll = useRef(false);

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -24,17 +24,21 @@ import DeviceInfo from 'react-native-device-info';
 import SvgIcon from '../components/SvgIcon';
 import { RootStackParamList } from '../types/navigation';
 import { FCM_SERMON_KEY } from '../types/Sermon';
+import { FCM_QT_KEY } from '../types/QT';
 import WidgetUpdateModule from '../types/WidgetUpdateModule';
+import { fetchLatestSermonFromServer } from '../services/sermonService';
+import { fetchLatestQtFromServer } from '../services/qtService';
 import { logAnalytics } from '../utils/analytics';
 import logger from '../utils/logger';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'SettingsScreen'>;
 
-const SettingsScreen = ({ navigation, route }: Props) => {
+const SettingsScreen = ({ navigation }: Props) => {
   const [showDeveloperMenu, setShowDeveloperMenu] = useState(false);
   const [tapCount, setTapCount] = useState(0);
   const [fcmToken, setFcmToken] = useState<string | null>(null);
   const [youtubeLinkEnabled, setYoutubeLinkEnabled] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
 
   const toggleDeveloperMenu = () => {
     const newTapCount = tapCount + 1;
@@ -59,16 +63,31 @@ const SettingsScreen = ({ navigation, route }: Props) => {
   };
 
   const clearAndRefreshStorage = async () => {
+    if (isRefreshing) return;
+    setIsRefreshing(true);
     logAnalytics.dataRefresh();
     try {
-      await AsyncStorage.removeItem(FCM_SERMON_KEY);
-      logger.log('Widget Preferences cleared');
-      if (WidgetUpdateModule) {
-        await WidgetUpdateModule.onClear();
-      }
-      await route.params.onRefresh?.();
+      const [sermon, qt] = await Promise.all([
+        fetchLatestSermonFromServer(),
+        fetchLatestQtFromServer(),
+      ]);
+      await AsyncStorage.multiRemove([FCM_SERMON_KEY, FCM_QT_KEY]);
+      if (sermon) await AsyncStorage.setItem(FCM_SERMON_KEY, JSON.stringify(sermon));
+      if (qt) await AsyncStorage.setItem(FCM_QT_KEY, JSON.stringify(qt));
+      if (WidgetUpdateModule) await WidgetUpdateModule.onClear();
+      Alert.alert('완료', '데이터가 최신으로 갱신되었습니다.');
     } catch (error) {
-      logger.error('Error clearing local storage:', error);
+      logger.error('Error refreshing data:', error);
+      const code = (error as { code?: string }).code ?? '';
+      if (code.includes('unavailable') || code.includes('deadline-exceeded')) {
+        Alert.alert('네트워크 오류', '인터넷 연결을 확인하고 다시 시도해주세요.');
+      } else if (code.includes('permission-denied') || code.includes('resource-exhausted')) {
+        Alert.alert('서버 오류', '서버에 접근할 수 없습니다. 잠시 후 다시 시도해주세요.');
+      } else {
+        Alert.alert('오류', '데이터 갱신에 실패했습니다. 잠시 후 다시 시도해주세요.');
+      }
+    } finally {
+      setIsRefreshing(false);
     }
   };
 
@@ -188,8 +207,14 @@ const SettingsScreen = ({ navigation, route }: Props) => {
           <Text style={styles.sectionDescription}>
             교회 홈페이지에서 최신 설교 말씀을 받아옵니다.
           </Text>
-          <TouchableOpacity onPress={clearAndRefreshStorage} style={styles.primaryButton}>
-            <Text style={styles.primaryButtonText}>데이터 새로고침</Text>
+          <TouchableOpacity
+            onPress={clearAndRefreshStorage}
+            style={[styles.primaryButton, isRefreshing && styles.primaryButtonDisabled]}
+            disabled={isRefreshing}
+          >
+            <Text style={styles.primaryButtonText}>
+              {isRefreshing ? '갱신 중...' : '데이터 새로고침'}
+            </Text>
           </TouchableOpacity>
 
           {showDeveloperMenu && (
@@ -350,6 +375,9 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     marginTop: 8,
+  },
+  primaryButtonDisabled: {
+    backgroundColor: '#A59EAE',
   },
   primaryButtonText: {
     color: 'white',

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -71,11 +71,18 @@ const SettingsScreen = ({ navigation }: Props) => {
         fetchLatestSermonFromServer(),
         fetchLatestQtFromServer(),
       ]);
-      await AsyncStorage.multiRemove([FCM_SERMON_KEY, FCM_QT_KEY]);
+      const keysToRemove: string[] = [];
+      if (sermon) keysToRemove.push(FCM_SERMON_KEY);
+      if (qt) keysToRemove.push(FCM_QT_KEY);
+      if (keysToRemove.length === 0) {
+        Alert.alert('알림', '서버에서 데이터를 찾을 수 없습니다.');
+        return;
+      }
+      await AsyncStorage.multiRemove(keysToRemove);
       if (sermon) await AsyncStorage.setItem(FCM_SERMON_KEY, JSON.stringify(sermon));
       if (qt) await AsyncStorage.setItem(FCM_QT_KEY, JSON.stringify(qt));
       if (WidgetUpdateModule) await WidgetUpdateModule.onClear();
-      Alert.alert('완료', '데이터가 최신으로 갱신되었습니다.');
+      Alert.alert('완료', '데이터를 새로 불러왔습니다.');
     } catch (error) {
       logger.error('Error refreshing data:', error);
       const code = (error as { code?: string }).code ?? '';
@@ -84,7 +91,7 @@ const SettingsScreen = ({ navigation }: Props) => {
       } else if (code.includes('permission-denied') || code.includes('resource-exhausted')) {
         Alert.alert('서버 오류', '서버에 접근할 수 없습니다. 잠시 후 다시 시도해주세요.');
       } else {
-        Alert.alert('오류', '데이터 갱신에 실패했습니다. 잠시 후 다시 시도해주세요.');
+        Alert.alert('오류', '데이터 불러오기에 실패했습니다. 잠시 후 다시 시도해주세요.');
       }
     } finally {
       setIsRefreshing(false);
@@ -213,7 +220,7 @@ const SettingsScreen = ({ navigation }: Props) => {
             disabled={isRefreshing}
           >
             <Text style={styles.primaryButtonText}>
-              {isRefreshing ? '갱신 중...' : '데이터 새로고침'}
+              {isRefreshing ? '불러오는 중...' : '데이터 새로고침'}
             </Text>
           </TouchableOpacity>
 

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -2,7 +2,5 @@ import { Sermon } from "./Sermon";
 export type RootStackParamList = {
   MainTabs: undefined;
   EditScreen: { sermon?: Sermon };
-  SettingsScreen: {
-    onRefresh?: () => void;
-  };
+  SettingsScreen: undefined;
 };


### PR DESCRIPTION
## 배경

탭 네비게이터 전환(ISSUE-50) 이후 설정화면 새로고침 버튼이 실질적으로 동작하지 않는 상태였습니다.
- `onRefresh` 콜백이 `MainTabNavigator`에서 전달되지 않아 호출 불가
- `FCM_SERMON_KEY`만 삭제하고 QT 키는 미처리
- 서버 fetch 후 AsyncStorage 저장 로직 없음

## 변경 내용

**SettingsScreen**
- `clearAndRefreshStorage`: Firestore에서 sermon/qt fetch → AsyncStorage 갱신 → 위젯 초기화 순서로 재작성 (fetch-first, 네트워크 실패 시 기존 데이터 보존)
- `isRefreshing` 상태 추가로 실행 중 버튼 비활성화 및 중복 탭 방지

**HomeScreen / DailyMannaScreen**
- `useFocusEffect` 추가: 설정화면에서 돌아올 때 `loadLocalData()` 자동 호출로 갱신된 데이터 즉시 반영
- `useRef`로 초기 마운트 시 `loadLocalData()` 중복 호출 방지

**navigation.ts / MainTabNavigator**
- `SettingsScreen` 파라미터에서 불필요한 `onRefresh` 제거

## 새로고침 흐름

버튼 클릭
→ Firestore fetch (sermon + qt)
→ AsyncStorage 갱신
→ 설정화면에서 뒤로가기
→ useFocusEffect → loadLocalData()
→ 화면 + 위젯 업데이트



## 알려진 한계
- iOS: `bible_references` 필드가 있는 경우 `content`가 빈 문자열로 저장됨 (iOS native 작업 완료 후 해결 예정)
