### PR TITLE
[ISSUE-103] 위젯 UI 개선 및 패키지 업데이트

### DIFF
--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetLarge.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetLarge.kt
@@ -112,7 +112,7 @@ private fun QtWidgetLargeContent(ui: QtWidgetUiModel, clickAction: Action) {
                 )
             }
             if (ui.questions.isNotEmpty()) {
-                val numberedQuestions = ui.questions.mapIndexed { index, q -> "${index + 1}. $q" }
+                val bulletedQuestions = ui.questions.map { question -> "• $question" }
                 item { Spacer(GlanceModifier.height(VerseLargeQtDimens.sectionGap)) }
                 item {
                     Text(
@@ -122,13 +122,13 @@ private fun QtWidgetLargeContent(ui: QtWidgetUiModel, clickAction: Action) {
                     )
                 }
                 item { Spacer(GlanceModifier.height(VerseLargeQtDimens.sectionInnerGap)) }
-                items(numberedQuestions) { numbered ->
+                items(bulletedQuestions) { question ->
                     Text(
                         modifier = GlanceModifier
                             .fillMaxWidth()
                             .padding(horizontal = VerseLargeQtDimens.horizontalPadding)
                             .clickable(clickAction),
-                        text = numbered,
+                        text = question,
                         style = Typography.titleMedium.copy(fontWeight = FontWeight.Normal),
                     )
                 }

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetSmall.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetSmall.kt
@@ -116,6 +116,7 @@ private fun QtWidgetSmallContent(ui: QtWidgetUiModel, clickAction: Action) {
                     )
                 }
                 if (ui.questions.isNotEmpty()) {
+                    val bulletedQuestions = ui.questions.map { question -> "• $question" }
                     item { Spacer(GlanceModifier.height(VerseSmallQtDimens.sectionGap)) }
                     item {
                         Box(
@@ -140,16 +141,16 @@ private fun QtWidgetSmallContent(ui: QtWidgetUiModel, clickAction: Action) {
                         )
                     }
                     item { Spacer(GlanceModifier.height(VerseSmallQtDimens.sectionGap)) }
-                    
-                    ui.questions.forEachIndexed { index, question ->
+
+                    bulletedQuestions.forEachIndexed { index, question ->
                         item {
                             Text(
                                 modifier = GlanceModifier.padding(horizontal = VerseSmallQtDimens.contentPadding),
-                                text = "${index + 1}. $question",
+                                text = question,
                                 style = Typography.bodyMedium,
                             )
                         }
-                        if (index < ui.questions.size - 1) {
+                        if (index < bulletedQuestions.size - 1) {
                             item { Spacer(GlanceModifier.height(VerseSmallQtDimens.sectionGap)) }
                         }
                     }

--- a/android/app/src/main/res/layout/verse_widget_large_error.xml
+++ b/android/app/src/main/res/layout/verse_widget_large_error.xml
@@ -6,8 +6,8 @@
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="56.dp"
-        android:paddingHorizontal="24.dp">
+        android:layout_height="56dp"
+        android:paddingHorizontal="24dp">
 
         <TextView
             android:layout_width="wrap_content"
@@ -16,7 +16,7 @@
             android:text="@string/widget_error_title"
             android:textColor="@android:color/black"
             android:textFontWeight="700"
-            android:textSize="16.sp" />
+            android:textSize="16sp" />
     </FrameLayout>
 
     <TextView
@@ -25,6 +25,6 @@
         android:layout_gravity="center"
         android:text="@string/widget_error_message"
         android:textColor="@android:color/black"
-        android:textSize="18.sp"
+        android:textSize="18sp"
         android:textStyle="bold" />
 </FrameLayout>

--- a/android/app/src/main/res/layout/verse_widget_large_preview.xml
+++ b/android/app/src/main/res/layout/verse_widget_large_preview.xml
@@ -22,8 +22,8 @@ private object VerseLargeWidgetDimens {
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="56.dp"
-        android:paddingHorizontal="24.dp">
+        android:layout_height="56dp"
+        android:paddingHorizontal="24dp">
 
         <!--Typography.titleMedium.copy(fontWeight = FontWeight.Bold)-->
         <TextView
@@ -33,30 +33,30 @@ private object VerseLargeWidgetDimens {
             android:text="@string/widget_preview_title"
             android:textColor="@android:color/black"
             android:textFontWeight="700"
-            android:textSize="16.sp" />
+            android:textSize="16sp" />
     </FrameLayout>
 
     <!--Typography.titleMedium.copy(fontWeight = FontWeight.Normal)-->
     <TextView
         android:layout_width="wrap_content"
-        android:layout_height="0.dp"
+        android:layout_height="0dp"
         android:layout_weight="1"
-        android:paddingHorizontal="24.dp"
+        android:paddingHorizontal="24dp"
         android:scrollbars="vertical"
         android:text="@string/widget_preview_verses"
         android:textColor="@android:color/black"
         android:textFontWeight="400"
-        android:textSize="16.sp" />
+        android:textSize="16sp" />
 
     <!--Typography.labelMedium-->
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="12.dp"
-        android:paddingHorizontal="24.dp"
-        android:paddingBottom="24.dp"
+        android:layout_marginTop="12dp"
+        android:paddingHorizontal="24dp"
+        android:paddingBottom="24dp"
         android:text="@string/widget_preview_books"
         android:textColor="@android:color/black"
         android:textFontWeight="500"
-        android:textSize="12.sp" />
+        android:textSize="12sp" />
 </LinearLayout>

--- a/android/app/src/main/res/layout/verse_widget_qt_large_error.xml
+++ b/android/app/src/main/res/layout/verse_widget_qt_large_error.xml
@@ -6,8 +6,8 @@
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="56.dp"
-        android:paddingHorizontal="24.dp">
+        android:layout_height="56dp"
+        android:paddingHorizontal="24dp">
 
         <TextView
             android:layout_width="wrap_content"
@@ -16,7 +16,7 @@
             android:text="@string/widget_error_title"
             android:textColor="@android:color/black"
             android:textFontWeight="700"
-            android:textSize="16.sp" />
+            android:textSize="16sp" />
     </FrameLayout>
 
     <TextView
@@ -25,6 +25,6 @@
         android:layout_gravity="center"
         android:text="@string/widget_error_message"
         android:textColor="@android:color/black"
-        android:textSize="18.sp"
+        android:textSize="18sp"
         android:textStyle="bold" />
 </FrameLayout>

--- a/android/app/src/main/res/layout/verse_widget_qt_large_preview.xml
+++ b/android/app/src/main/res/layout/verse_widget_qt_large_preview.xml
@@ -4,24 +4,24 @@
     android:layout_height="match_parent"
     android:background="@drawable/gradient_background"
     android:orientation="vertical"
-    android:paddingTop="12.dp">
+    android:paddingTop="12dp">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:paddingHorizontal="24.dp">
+        android:paddingHorizontal="24dp">
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="4월 26일 · 화"
             android:textColor="#99000000"
-            android:textSize="11.sp" />
+            android:textSize="11sp" />
 
-        <Space
+        <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="4.dp" />
+            android:layout_height="4dp" />
 
         <TextView
             android:layout_width="wrap_content"
@@ -29,58 +29,53 @@
             android:text="@string/widget_qt_preview_title"
             android:textColor="@android:color/black"
             android:textFontWeight="700"
-            android:textSize="16.sp" />
+            android:textSize="16sp" />
     </LinearLayout>
 
-    <ScrollView
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="0.dp"
+        android:layout_height="0dp"
         android:layout_weight="1"
-        android:paddingTop="12.dp">
-        
-        <LinearLayout
+        android:paddingHorizontal="24dp"
+        android:paddingTop="12dp"
+        android:paddingBottom="24dp"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/widget_qt_preview_books"
+            android:textColor="@android:color/black"
+            android:textFontWeight="500"
+            android:textSize="12sp" />
+
+        <FrameLayout android:layout_width="match_parent" android:layout_height="8dp" />
+
+        <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingHorizontal="24.dp"
-            android:paddingBottom="24.dp"
-            android:orientation="vertical">
+            android:text="@string/widget_qt_preview_verses"
+            android:textColor="@android:color/black"
+            android:textSize="16sp" />
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/widget_qt_preview_books"
-                android:textColor="@android:color/black"
-                android:textFontWeight="500"
-                android:textSize="12.sp" />
+        <FrameLayout android:layout_width="match_parent" android:layout_height="16dp" />
 
-            <Space android:layout_width="wrap_content" android:layout_height="8.dp" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="묵상 질문"
+            android:textColor="@android:color/black"
+            android:textFontWeight="500"
+            android:textSize="12sp" />
 
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/widget_qt_preview_verses"
-                android:textColor="@android:color/black"
-                android:textSize="16.sp" />
+        <FrameLayout android:layout_width="match_parent" android:layout_height="8dp" />
 
-            <Space android:layout_width="wrap_content" android:layout_height="16.dp" />
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="1. 오늘 말씀을 통해 무엇을 깨달았나요?\n2. 삶에 어떻게 적용할 수 있을까요?"
+            android:textColor="@android:color/black"
+            android:textSize="16sp" />
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="묵상 질문"
-                android:textColor="@android:color/black"
-                android:textFontWeight="500"
-                android:textSize="12.sp" />
-
-            <Space android:layout_width="wrap_content" android:layout_height="8.dp" />
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="1. 오늘 말씀을 통해 무엇을 깨달았나요?\n2. 삶에 어떻게 적용할 수 있을까요?"
-                android:textColor="@android:color/black"
-                android:textSize="16.sp" />
-
-        </LinearLayout>
-    </ScrollView>
+    </LinearLayout>
 </LinearLayout>

--- a/android/app/src/main/res/layout/verse_widget_qt_small_error.xml
+++ b/android/app/src/main/res/layout/verse_widget_qt_small_error.xml
@@ -7,8 +7,8 @@
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="56.dp"
-        android:paddingHorizontal="24.dp">
+        android:layout_height="56dp"
+        android:paddingHorizontal="24dp">
 
         <TextView
             android:layout_width="wrap_content"
@@ -17,18 +17,18 @@
             android:text="@string/widget_error_title"
             android:textColor="@android:color/black"
             android:textFontWeight="500"
-            android:textSize="16.sp" />
+            android:textSize="16sp" />
     </FrameLayout>
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="0.dp"
-        android:layout_marginStart="12.dp"
-        android:layout_marginEnd="12.dp"
-        android:layout_marginBottom="12.dp"
+        android:layout_height="0dp"
+        android:layout_marginStart="12dp"
+        android:layout_marginEnd="12dp"
+        android:layout_marginBottom="12dp"
         android:layout_weight="1"
         android:background="@drawable/rounded_gradient_background"
-        android:padding="12.dp">
+        android:padding="12dp">
 
         <TextView
             android:layout_width="wrap_content"
@@ -37,7 +37,7 @@
             android:text="@string/widget_error_message"
             android:textAlignment="center"
             android:textColor="@android:color/black"
-            android:textSize="18.sp"
+            android:textSize="18sp"
             android:textStyle="bold" />
     </FrameLayout>
 </LinearLayout>

--- a/android/app/src/main/res/layout/verse_widget_qt_small_preview.xml
+++ b/android/app/src/main/res/layout/verse_widget_qt_small_preview.xml
@@ -9,8 +9,8 @@
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingHorizontal="24.dp"
-        android:paddingVertical="20.dp">
+        android:paddingHorizontal="24dp"
+        android:paddingVertical="20dp">
 
         <TextView
             android:layout_width="wrap_content"
@@ -18,18 +18,18 @@
             android:text="@string/widget_qt_preview_title"
             android:textColor="@android:color/black"
             android:textFontWeight="500"
-            android:textSize="16.sp" />
+            android:textSize="16sp" />
     </FrameLayout>
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="0.dp"
-        android:layout_marginHorizontal="12.dp"
-        android:layout_marginBottom="12.dp"
+        android:layout_height="0dp"
+        android:layout_marginHorizontal="12dp"
+        android:layout_marginBottom="12dp"
         android:layout_weight="1"
         android:background="@drawable/rounded_gradient_background"
         android:orientation="vertical"
-        android:padding="12.dp">
+        android:padding="12dp">
 
         <TextView
             android:layout_width="wrap_content"
@@ -37,9 +37,9 @@
             android:text="@string/widget_qt_preview_books"
             android:textColor="@android:color/black"
             android:textFontWeight="500"
-            android:textSize="11.sp" />
+            android:textSize="11sp" />
 
-        <Space android:layout_width="wrap_content" android:layout_height="8.dp" />
+        <FrameLayout android:layout_width="match_parent" android:layout_height="8dp" />
 
         <TextView
             android:layout_width="match_parent"
@@ -48,16 +48,16 @@
             android:textColor="@android:color/black"
             android:maxLines="3"
             android:ellipsize="end"
-            android:textSize="14.sp" />
+            android:textSize="14sp" />
 
-        <Space android:layout_width="wrap_content" android:layout_height="8.dp" />
+        <FrameLayout android:layout_width="match_parent" android:layout_height="8dp" />
 
-        <View
+        <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="1.dp"
+            android:layout_height="1dp"
             android:background="#33000000" />
 
-        <Space android:layout_width="wrap_content" android:layout_height="8.dp" />
+        <FrameLayout android:layout_width="match_parent" android:layout_height="8dp" />
 
         <TextView
             android:layout_width="wrap_content"
@@ -65,9 +65,9 @@
             android:text="묵상 질문"
             android:textColor="@android:color/black"
             android:textFontWeight="500"
-            android:textSize="11.sp" />
+            android:textSize="11sp" />
 
-        <Space android:layout_width="wrap_content" android:layout_height="8.dp" />
+        <FrameLayout android:layout_width="match_parent" android:layout_height="8dp" />
 
         <TextView
             android:layout_width="match_parent"
@@ -76,14 +76,14 @@
             android:textColor="@android:color/black"
             android:maxLines="2"
             android:ellipsize="end"
-            android:textSize="14.sp" />
+            android:textSize="14sp" />
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="+1"
             android:textColor="@android:color/black"
-            android:textSize="11.sp" />
+            android:textSize="11sp" />
     </LinearLayout>
 
 </LinearLayout>

--- a/android/app/src/main/res/layout/verse_widget_small_error.xml
+++ b/android/app/src/main/res/layout/verse_widget_small_error.xml
@@ -7,8 +7,8 @@
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="56.dp"
-        android:paddingHorizontal="24.dp">
+        android:layout_height="56dp"
+        android:paddingHorizontal="24dp">
 
         <TextView
             android:layout_width="wrap_content"
@@ -17,18 +17,18 @@
             android:text="@string/widget_error_title"
             android:textColor="@android:color/black"
             android:textFontWeight="500"
-            android:textSize="16.sp" />
+            android:textSize="16sp" />
     </FrameLayout>
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="0.dp"
-        android:layout_marginStart="12.dp"
-        android:layout_marginEnd="12.dp"
-        android:layout_marginBottom="12.dp"
+        android:layout_height="0dp"
+        android:layout_marginStart="12dp"
+        android:layout_marginEnd="12dp"
+        android:layout_marginBottom="12dp"
         android:layout_weight="1"
         android:background="@drawable/rounded_gradient_background"
-        android:padding="12.dp">
+        android:padding="12dp">
 
         <TextView
             android:layout_width="wrap_content"
@@ -37,7 +37,7 @@
             android:text="@string/widget_error_message"
             android:textAlignment="center"
             android:textColor="@android:color/black"
-            android:textSize="18.sp"
+            android:textSize="18sp"
             android:textStyle="bold" />
     </FrameLayout>
 </LinearLayout>

--- a/android/app/src/main/res/layout/verse_widget_small_preview.xml
+++ b/android/app/src/main/res/layout/verse_widget_small_preview.xml
@@ -24,8 +24,8 @@ private object VerseSmallWidgetDimens {
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="56.dp"
-        android:paddingHorizontal="24.dp">
+        android:layout_height="56dp"
+        android:paddingHorizontal="24dp">
 
         <!--Typography.titleMedium-->
         <TextView
@@ -35,39 +35,39 @@ private object VerseSmallWidgetDimens {
             android:text="@string/widget_preview_title"
             android:textColor="@android:color/black"
             android:textFontWeight="500"
-            android:textSize="16.sp" />
+            android:textSize="16sp" />
     </FrameLayout>
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="0.dp"
-        android:layout_marginHorizontal="12.dp"
-        android:layout_marginBottom="12.dp"
+        android:layout_height="0dp"
+        android:layout_marginHorizontal="12dp"
+        android:layout_marginBottom="12dp"
         android:layout_weight="1"
         android:background="@drawable/rounded_gradient_background"
         android:orientation="vertical"
-        android:padding="12.dp">
+        android:padding="12dp">
         <!--Typography.bodyMedium-->
         <TextView
             android:layout_width="match_parent"
-            android:layout_height="0.dp"
+            android:layout_height="0dp"
             android:layout_weight="1"
             android:scrollbars="vertical"
             android:text="@string/widget_preview_verses"
             android:textColor="@android:color/black"
             android:textFontWeight="400"
-            android:textSize="14.sp"
+            android:textSize="14sp"
             tools:ignore="NestedWeights" />
 
         <!--Typography.labelSmall-->
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8.dp"
+            android:layout_marginTop="8dp"
             android:text="@string/widget_preview_books"
             android:textColor="@android:color/black"
             android:textFontWeight="500"
-            android:textSize="11.sp" />
+            android:textSize="11sp" />
     </LinearLayout>
 
 </LinearLayout>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -7,4 +7,8 @@
     <string name="verse_widget_large_description">이번 주 성경 말씀을 배너형으로 보여줍니다.</string>
     <string name="widget_error_message">말씀 내용을 불러올 수 없습니다.</string>
     <string name="widget_error_title">묵상만개</string>
+    <string name="verse_widget_qt_small_name">매일 만나 (카드형)</string>
+    <string name="verse_widget_qt_small_description">오늘의 매일 만나 말씀을 카드형으로 보여줍니다.</string>
+    <string name="verse_widget_qt_large_name">매일 만나 (배너형)</string>
+    <string name="verse_widget_qt_large_description">오늘의 매일 만나 말씀을 배너형으로 보여줍니다.</string>
 </resources>

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-native-pager-view": "^8.0.0",
     "react-native-safe-area-context": "^5.5.0",
     "react-native-screens": "^4.10.0",
-    "react-native-svg": "^15.12.0",
+    "react-native-svg": "15.15.5",
     "react-native-tab-view": "^4.2.2",
     "react-native-vector-icons": "^10.2.0",
     "sp-react-native-in-app-updates": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7488,14 +7488,13 @@ react-native-svg-transformer@^1.5.1:
     "@svgr/plugin-svgo" "^8.1.0"
     path-dirname "^1.0.2"
 
-react-native-svg@^15.12.0:
-  version "15.12.1"
-  resolved "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.1.tgz"
-  integrity sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==
+react-native-svg@15.15.5:
+  version "15.15.5"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-15.15.5.tgz#822805c14481b8ec16d5fbac1e3ce2b27a5509d7"
+  integrity sha512-L4go5jA+GWutdJ/JucuN20cjAbMg1HmMtAP+wZ+3JLCf6Jd0bhXQHxciRP/AQm/FlrIEZwkMcHNZP+FXAiic0w==
   dependencies:
     css-select "^5.1.0"
     css-tree "^1.1.3"
-    warn-once "0.1.1"
 
 react-native-tab-view@^4.2.2:
   version "4.2.2"
@@ -8665,7 +8664,7 @@ walker@^1.0.7, walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
-warn-once@0.1.1, warn-once@^0.1.0, warn-once@^0.1.1:
+warn-once@^0.1.0, warn-once@^0.1.1:
   version "0.1.1"
   resolved "https://registry.npmjs.org/warn-once/-/warn-once-0.1.1.tgz"
   integrity sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==


### PR DESCRIPTION
## Summary
- QT 위젯(대형/소형) 묵상 질문 표시 방식을 번호(1. 2.)에서 불릿 포인트(•)로 변경
- Android XML 레이아웃 파일의 치수 표기 오류 수정 (`56.dp` → `56dp`, `24.dp` → `24dp` 등)
- 매일 만나 위젯(카드형/배너형) 한국어 이름 및 설명 문자열 리소스 추가
- `react-native-svg` 버전 `^15.12.0` → `15.15.5` 고정 버전으로 업데이트

## Test plan
- [ ] Android 빌드 정상 확인
- [ ] QT 위젯 소형/대형에서 묵상 질문이 불릿 포인트(•)로 표시되는지 확인
- [ ] 위젯 미리보기 및 에러 레이아웃 렌더링 정상 확인
- [ ] 매일 만나 위젯 이름/설명이 한국어로 올바르게 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)