### PR TITLE
[ISSUE-103] ci: Firebase App Distribution 배포 단계 추가

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Build Android Release
       run: |
         cd android
-        ./gradlew bundleRelease --no-daemon
+        ./gradlew bundleRelease assembleRelease --no-daemon
 
     - name: Upload AAB
       uses: actions/upload-artifact@v4
@@ -65,10 +65,18 @@ jobs:
         name: Release ${{ github.ref_name }}
         body: |
           Release ${{ github.ref_name }}
-          
+
           Changes in this release:
           - 자동 생성된 릴리스
         draft: false
         prerelease: false
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Upload to Firebase App Distribution
+      uses: wzieba/Firebase-Distribution-Github-Action@v1
+      with:
+        appId: 1:885722038359:android:464defc0b9c3502b5b6312
+        token: ${{ secrets.FIREBASE_TOKEN }}
+        groups: testers
+        file: android/app/build/outputs/apk/release/app-release.apk


### PR DESCRIPTION
## Summary
- 태그 푸시 시 Firebase App Distribution에 APK 자동 업로드 추가
- 기존 AAB GitHub Release는 유지, APK도 함께 빌드 (`assembleRelease` 추가)
- 배포 대상 그룹: `testers`

## 필요한 GitHub Secret
- `FIREBASE_TOKEN`: `firebase login:ci`로 발급한 토큰

## Test plan
- [ ] `FIREBASE_TOKEN` 시크릿이 GitHub repo에 설정되어 있는지 확인
- [ ] 태그 푸시 후 Firebase App Distribution에 빌드가 업로드되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)