### PR TITLE
[ISSUE-106] Firebase App Distribution Service Account 전환 및 테스트 그룹 설정

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -77,6 +77,6 @@ jobs:
       uses: wzieba/Firebase-Distribution-Github-Action@v1
       with:
         appId: 1:885722038359:android:464defc0b9c3502b5b6312
-        token: ${{ secrets.FIREBASE_TOKEN }}
-        groups: testers
+        serviceCredentialsFileContent: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        groups: 내부테스트
         file: android/app/build/outputs/apk/release/app-release.apk

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Secrets
+.secrets/
+
 # OSX
 #
 .DS_Store


### PR DESCRIPTION
## Summary

- Firebase App Distribution 인증을 `FIREBASE_TOKEN` → `serviceCredentialsFileContent` (Service Account)로 전환
- 배포 테스트 그룹 `testers` → `내부테스트`로 변경
- `.secrets/` 폴더를 `.gitignore`에 추가

## Test plan

- [ ] `v*` 태그 푸시 시 GitHub Actions 빌드 성공 확인
- [ ] Firebase App Distribution에 `내부테스트` 그룹으로 APK 배포 확인

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)