### PR TITLE
[ISSUE-98] feat: FCM 실패 대비 Firestore onSnapshot 구독으로 자동 업데이트

### DIFF
--- a/__tests__/sermonService.test.ts
+++ b/__tests__/sermonService.test.ts
@@ -2,15 +2,15 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   fetchLatestSermonFromAsyncStorage,
   isSermonDataStale,
+  saveSermonToAsyncStorage,
   syncAppGroupToAsyncStorage,
 } from '../src/services/sermonService';
+import { Sermon } from '../src/types/Sermon';
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn(),
   setItem: jest.fn(),
 }));
-
-jest.mock('@react-native-firebase/firestore', () => ({}));
 
 jest.mock('../src/types/WidgetUpdateModule', () => null);
 
@@ -120,5 +120,29 @@ describe('syncAppGroupToAsyncStorage', () => {
     const result = await syncAppGroupToAsyncStorage('not-json{{{', null);
     expect(result).toBeNull();
     expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+  });
+});
+
+
+describe('saveSermonToAsyncStorage', () => {
+  const sermon: Sermon = {
+    id: 'save-test-1',
+    title: '저장 테스트',
+    content: '내용',
+    date: '2025-05-18',
+    created_at: { seconds: 0, nanoseconds: 0 },
+    updated_at: { seconds: 0, nanoseconds: 0 },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('AsyncStorage에 fcm_sermon 키로 JSON 저장', async () => {
+    (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+
+    await saveSermonToAsyncStorage(sermon);
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('fcm_sermon', JSON.stringify(sermon));
   });
 });

--- a/__tests__/useSermonData.test.ts
+++ b/__tests__/useSermonData.test.ts
@@ -2,9 +2,16 @@ import { act, renderHook } from '@testing-library/react-native';
 import { useSermonData } from '../src/hooks/useSermonData';
 import * as sermonService from '../src/services/sermonService';
 
+jest.mock('@react-native-firebase/analytics', () => ({
+  getAnalytics: jest.fn(),
+  logEvent: jest.fn().mockResolvedValue(undefined),
+}));
+
 jest.mock('../src/services/sermonService', () => ({
   fetchLatestSermonFromAsyncStorage: jest.fn(),
   fetchLatestSermonFromServer: jest.fn(),
+  saveSermonToAsyncStorage: jest.fn(),
+  subscribeToLatestSermon: jest.fn(() => jest.fn()), // returns unsubscribe fn
 }));
 
 jest.mock('../src/utils/logger', () => ({
@@ -14,6 +21,8 @@ jest.mock('../src/utils/logger', () => ({
 
 const mockFetchFromAsyncStorage = sermonService.fetchLatestSermonFromAsyncStorage as jest.Mock;
 const mockFetchFromServer = sermonService.fetchLatestSermonFromServer as jest.Mock;
+const mockSaveSermonToAsyncStorage = sermonService.saveSermonToAsyncStorage as jest.Mock;
+const mockSubscribeToLatestSermon = sermonService.subscribeToLatestSermon as jest.Mock;
 
 const mockSermon = {
   id: 'test-1',
@@ -143,6 +152,73 @@ describe('useSermonData', () => {
 
       expect(mockFetchFromServer).toHaveBeenCalledTimes(1);
       expect(result.current.sermon).toEqual(mockSermon);
+    });
+  });
+
+  describe('subscribeToLatestSermon (onSnapshot)', () => {
+    const olderSermon = {
+      id: 'older-1',
+      title: '이전 설교',
+      content: '내용',
+      date: '2025-04-06',
+      created_at: { seconds: 1000, nanoseconds: 0 },
+      updated_at: { seconds: 1000, nanoseconds: 0 },
+    };
+    const newerSermon = {
+      id: 'newer-1',
+      title: '최신 설교',
+      content: '내용',
+      date: '2025-05-18',
+      created_at: { seconds: 2000, nanoseconds: 0 },
+      updated_at: { seconds: 2000, nanoseconds: 0 },
+    };
+
+    it('마운트 시 subscribeToLatestSermon 호출됨', () => {
+      renderHook(() => useSermonData());
+      expect(mockSubscribeToLatestSermon).toHaveBeenCalledTimes(1);
+    });
+
+    it('언마운트 시 unsubscribe 함수 호출됨', () => {
+      const mockUnsubscribe = jest.fn();
+      mockSubscribeToLatestSermon.mockReturnValue(mockUnsubscribe);
+
+      const { unmount } = renderHook(() => useSermonData());
+      unmount();
+
+      expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it('더 최신 sermon이 오면 AsyncStorage 저장 후 상태 업데이트', async () => {
+      let capturedOnUpdate: (sermon: typeof newerSermon) => Promise<void>;
+      mockSubscribeToLatestSermon.mockImplementation((onUpdate: typeof capturedOnUpdate) => {
+        capturedOnUpdate = onUpdate;
+        return jest.fn();
+      });
+      mockSaveSermonToAsyncStorage.mockResolvedValue(undefined);
+      mockFetchFromAsyncStorage.mockResolvedValue(olderSermon);
+
+      const { result } = renderHook(() => useSermonData());
+      await act(async () => { await result.current.loadLocalData(); });
+      await act(async () => { await capturedOnUpdate(newerSermon); });
+
+      expect(mockSaveSermonToAsyncStorage).toHaveBeenCalledWith(newerSermon);
+      expect(result.current.sermon).toEqual(newerSermon);
+    });
+
+    it('동일하거나 이전 sermon이 오면 상태 유지', async () => {
+      let capturedOnUpdate: (sermon: typeof olderSermon) => Promise<void>;
+      mockSubscribeToLatestSermon.mockImplementation((onUpdate: typeof capturedOnUpdate) => {
+        capturedOnUpdate = onUpdate;
+        return jest.fn();
+      });
+      mockFetchFromAsyncStorage.mockResolvedValue(newerSermon);
+
+      const { result } = renderHook(() => useSermonData());
+      await act(async () => { await result.current.loadLocalData(); });
+      await act(async () => { await capturedOnUpdate(olderSermon); });
+
+      expect(mockSaveSermonToAsyncStorage).not.toHaveBeenCalled();
+      expect(result.current.sermon).toEqual(newerSermon);
     });
   });
 });

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -9,6 +9,7 @@ jest.mock('@react-native-firebase/firestore', () => ({
   getDocsFromServer: jest.fn(),
   getFirestore: jest.fn(),
   limit: jest.fn(),
+  onSnapshot: jest.fn(),
   orderBy: jest.fn(),
   query: jest.fn(),
 }));

--- a/src/hooks/useSermonData.ts
+++ b/src/hooks/useSermonData.ts
@@ -1,8 +1,10 @@
-import { useCallback, useState } from 'react';
-import { Sermon } from '../types/Sermon';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { compareSermon, Sermon } from '../types/Sermon';
 import {
   fetchLatestSermonFromAsyncStorage,
   fetchLatestSermonFromServer,
+  saveSermonToAsyncStorage,
+  subscribeToLatestSermon,
 } from '../services/sermonService';
 import { logAnalytics } from '../utils/analytics';
 import logger from '../utils/logger';
@@ -21,6 +23,8 @@ export function useSermonData(): UseSermonDataReturn {
   const [sermon, setSermon] = useState<Sermon | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const sermonRef = useRef<Sermon | null>(null);
+  sermonRef.current = sermon;
 
   const loadLocalData = useCallback(async (): Promise<Sermon | null> => {
     try {
@@ -57,6 +61,19 @@ export function useSermonData(): UseSermonDataReturn {
     } finally {
       setIsLoading(false);
     }
+  }, []);
+
+  useEffect(() => {
+    return subscribeToLatestSermon(
+      async (fresh) => {
+        if (compareSermon(fresh, sermonRef.current) > 0) {
+          logger.log('onSnapshot: newer sermon received, updating');
+          await saveSermonToAsyncStorage(fresh);
+          setSermon(fresh);
+        }
+      },
+      (e) => logger.error('Firestore subscription error:', e),
+    );
   }, []);
 
   const onRefresh = useCallback(async () => {

--- a/src/services/sermonService.ts
+++ b/src/services/sermonService.ts
@@ -4,6 +4,7 @@ import {
   getDocsFromServer,
   getFirestore,
   limit,
+  onSnapshot,
   orderBy,
   query,
 } from '@react-native-firebase/firestore';
@@ -30,6 +31,36 @@ export async function fetchLatestSermonFromAsyncStorage(): Promise<Sermon | null
     logger.error('Failed to load sermon from AsyncStorage', error);
   }
   return null;
+}
+
+export function subscribeToLatestSermon(
+  onUpdate: (sermon: Sermon) => void,
+  onError: (error: Error) => void,
+): () => void {
+  const db = getFirestore();
+  const q = query(
+    collection(db, 'sermons'),
+    orderBy('date', 'desc'),
+    limit(1),
+  );
+
+  return onSnapshot(
+    q,
+    async (snapshot) => {
+      if (snapshot.empty || snapshot.metadata.fromCache) return;
+      try {
+        const sermon = await firestoreDocToSermon(snapshot.docs[0]);
+        onUpdate(sermon);
+      } catch (e) {
+        onError(e instanceof Error ? e : new Error(String(e)));
+      }
+    },
+    onError,
+  );
+}
+
+export async function saveSermonToAsyncStorage(sermon: Sermon): Promise<void> {
+  await AsyncStorage.setItem(FCM_SERMON_KEY, JSON.stringify(sermon));
 }
 
 export async function fetchLatestSermonFromServer(): Promise<Sermon | null> {


### PR DESCRIPTION
- sermonService에 subscribeToLatestSermon() 추가: onSnapshot으로 서버 데이터 변경 시 자동 콜백 (fromCache 스냅샷은 제외하여 서버 확정 데이터만 처리)
- useSermonData에 구독 useEffect 추가: 최신 데이터 수신 시 compareSermon으로 비교 후 AsyncStorage 저장 및 상태 업데이트
- saveSermonToAsyncStorage 유틸 추가
- 기존 AppState 기반 수동 캐시 조회 방식 제거 (onSnapshot이 포그라운드 복귀 시 자동 처리)
- 관련 단위 테스트 추가/수정

Closes #98 
