### PR TITLE
[ISSUE-113] feat: 위젯 탭 시 해당 탭으로 이동

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -29,6 +29,12 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="meditationblossom" />
+            </intent-filter>
         </activity>
 
         <activity

--- a/android/app/src/main/java/app/mannadev/meditation/Constants.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/Constants.kt
@@ -15,4 +15,7 @@ object Constants {
     const val ASYNC_STORAGE_FCM_QT = "fcm_qt"
 
     const val FALLBACK_YOUTUBE_URL = "https://www.youtube.com/@만나"
+
+    const val DEEP_LINK_SUNDAY_SERMON = "meditationblossom://open?tab=sunday_sermon"
+    const val DEEP_LINK_DAILY_MANNA = "meditationblossom://open?tab=daily_manna"
 }

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetLarge.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetLarge.kt
@@ -21,6 +21,7 @@ import androidx.glance.layout.height
 import androidx.glance.layout.padding
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
+import app.mannadev.meditation.Constants
 import app.mannadev.meditation.R
 import app.mannadev.meditation.analytics.CrashlyticsHelper
 import app.mannadev.meditation.di.getWidgetDependencies
@@ -43,7 +44,7 @@ class QtWidgetLarge : GlanceAppWidget(
             null
         }
         val uiModel = qt?.let(QtWidgetUiModel::fromDto) ?: QtWidgetUiModel.error
-        val clickAction = widgetClickAction(uiModel.videoUrl)
+        val clickAction = widgetClickAction(uiModel.videoUrl, Constants.DEEP_LINK_DAILY_MANNA)
 
         provideContent { QtWidgetLargeContent(uiModel, clickAction) }
     }

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetSmall.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetSmall.kt
@@ -25,6 +25,7 @@ import androidx.glance.layout.padding
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
+import app.mannadev.meditation.Constants
 import app.mannadev.meditation.R
 import app.mannadev.meditation.analytics.CrashlyticsHelper
 import app.mannadev.meditation.di.getWidgetDependencies
@@ -47,7 +48,7 @@ class QtWidgetSmall : GlanceAppWidget(
             null
         }
         val uiModel = qt?.let(QtWidgetUiModel::fromDto) ?: QtWidgetUiModel.error
-        val clickAction = widgetClickAction(uiModel.videoUrl)
+        val clickAction = widgetClickAction(uiModel.videoUrl, Constants.DEEP_LINK_DAILY_MANNA)
 
         provideContent { QtWidgetSmallContent(uiModel, clickAction) }
     }

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/VerseWidgetLarge.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/VerseWidgetLarge.kt
@@ -21,6 +21,7 @@ import androidx.glance.layout.height
 import androidx.glance.layout.padding
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
+import app.mannadev.meditation.Constants
 import app.mannadev.meditation.R
 import app.mannadev.meditation.analytics.CrashlyticsHelper
 import app.mannadev.meditation.di.getWidgetDependencies
@@ -42,7 +43,7 @@ class VerseWidgetLarge : GlanceAppWidget(
             )
             Sermon.errorSermon
         }
-        val clickAction = widgetClickAction(verse.videoUrl)
+        val clickAction = widgetClickAction(verse.videoUrl, Constants.DEEP_LINK_SUNDAY_SERMON)
 
         provideContent {
             VerseWidgetLargeContent(verse, clickAction)

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/VerseWidgetSmall.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/VerseWidgetSmall.kt
@@ -24,6 +24,7 @@ import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.height
 import androidx.glance.layout.padding
 import androidx.glance.text.Text
+import app.mannadev.meditation.Constants
 import app.mannadev.meditation.R
 import app.mannadev.meditation.analytics.CrashlyticsHelper
 import app.mannadev.meditation.di.getWidgetDependencies
@@ -45,7 +46,7 @@ class VerseWidgetSmall : GlanceAppWidget(
             )
             Sermon.errorSermon
         }
-        val clickAction = widgetClickAction(verse.videoUrl)
+        val clickAction = widgetClickAction(verse.videoUrl, Constants.DEEP_LINK_SUNDAY_SERMON)
 
         provideContent {
             VerseWidgetSmallContent(verse, clickAction)

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/WidgetClickAction.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/WidgetClickAction.kt
@@ -3,5 +3,5 @@ package app.mannadev.meditation.ui.widget
 import androidx.glance.action.Action
 import androidx.glance.appwidget.action.actionRunCallback
 
-fun widgetClickAction(videoUrl: String?): Action =
-    actionRunCallback<YoutubeLinkClickAction>(YoutubeLinkClickAction.params(videoUrl))
+fun widgetClickAction(videoUrl: String?, deepLinkUrl: String): Action =
+    actionRunCallback<YoutubeLinkClickAction>(YoutubeLinkClickAction.params(videoUrl, deepLinkUrl))

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/YoutubeLinkClickAction.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/YoutubeLinkClickAction.kt
@@ -27,7 +27,9 @@ class YoutubeLinkClickAction : ActionCallback {
                     ?: FALLBACK_YOUTUBE_URL.toUri()
                 Intent(Intent.ACTION_VIEW, target)
             } else {
-                Intent(context, MainActivity::class.java)
+                val deepLinkUrl = parameters[DEEP_LINK_URL]
+                val target: Uri? = deepLinkUrl?.takeIf { it.isNotBlank() }?.toUri()
+                Intent(Intent.ACTION_VIEW, target ?: return@runCatching Intent(context, MainActivity::class.java))
             }
         }.getOrElse { e ->
             CrashlyticsHelper.recordException(e, "YoutubeLinkClickAction: fallback to app launch")
@@ -39,10 +41,13 @@ class YoutubeLinkClickAction : ActionCallback {
 
     companion object {
         val VIDEO_URL: ActionParameters.Key<String> = ActionParameters.Key("video_url")
+        val DEEP_LINK_URL: ActionParameters.Key<String> = ActionParameters.Key("deep_link_url")
 
-        fun params(videoUrl: String?): ActionParameters =
-            videoUrl?.takeIf { it.isNotBlank() }
-                ?.let { actionParametersOf(VIDEO_URL to it) }
-                ?: actionParametersOf()
+        fun params(videoUrl: String?, deepLinkUrl: String): ActionParameters =
+            if (videoUrl?.isNotBlank() == true) {
+                actionParametersOf(DEEP_LINK_URL to deepLinkUrl, VIDEO_URL to videoUrl)
+            } else {
+                actionParametersOf(DEEP_LINK_URL to deepLinkUrl)
+            }
     }
 }

--- a/ios/MeditationBlossomWidget/MeditationBlossomWidget.swift
+++ b/ios/MeditationBlossomWidget/MeditationBlossomWidget.swift
@@ -16,6 +16,7 @@ private enum WidgetConstants {
   static let displaySermonKey = "displaySermon"
   static let fcmSermonKey = "fcm_sermon"
   static let widgetKind = "MeditationBlossomWidget"
+  static let deepLinkSundaySermon = URL(string: "meditationblossom://open?tab=sunday_sermon")!
 }
 
 struct SimpleEntry: TimelineEntry {
@@ -144,9 +145,11 @@ struct MeditationBlossomWidget: Widget {
       if #available(iOS 17.0, *) {
         MeditationBlossomWidgetEntryView(entry: entry)
           .containerBackground(.fill.tertiary, for: .widget)
+          .widgetURL(WidgetConstants.deepLinkSundaySermon)
       } else {
         // iOS 16에서는 View 자체에 배경 적용
         MeditationBlossomWidgetEntryView(entry: entry)
+          .widgetURL(WidgetConstants.deepLinkSundaySermon)
       }
     }
     .supportedFamilies([.systemMedium, .systemLarge])

--- a/ios/meditation_blossom/Info.plist
+++ b/ios/meditation_blossom/Info.plist
@@ -90,5 +90,14 @@
 	<array>
 		<string>itms-apps</string>
 	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>meditationblossom</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ const TAB_DEEP_LINK_MAP: Record<string, string> = {
 const linking: LinkingOptions<RootStackParamList> = {
   prefixes: ['meditationblossom://'],
   getStateFromPath(path) {
-    const tab = new URLSearchParams(path.split('?')[1] ?? '').get('tab');
+    const tab = path.match(/[?&]tab=([^&]*)/)?.[1];
     const tabName = (tab && TAB_DEEP_LINK_MAP[tab]) ?? '주일 말씀';
     return {
       routes: [{ name: 'MainTabs', state: { routes: [{ name: tabName }] } }],

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,16 +5,32 @@ import MainTabNavigator from './navigation/MainTabNavigator';
 import EditScreen from './screens/EditScreen';
 import SettingsScreen from './screens/SettingsScreen';
 import ForceUpdateModal from './components/ForceUpdateModal';
-import { NavigationContainer } from '@react-navigation/native';
+import { LinkingOptions, NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { RootStackParamList } from './types/navigation';
 import { useForceUpdate } from './hooks/useForceUpdate';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
+const TAB_DEEP_LINK_MAP: Record<string, string> = {
+  daily_manna: '매일 만나',
+  sunday_sermon: '주일 말씀',
+};
+
+const linking: LinkingOptions<RootStackParamList> = {
+  prefixes: ['meditationblossom://'],
+  getStateFromPath(path) {
+    const tab = new URLSearchParams(path.split('?')[1] ?? '').get('tab');
+    const tabName = (tab && TAB_DEEP_LINK_MAP[tab]) ?? '주일 말씀';
+    return {
+      routes: [{ name: 'MainTabs', state: { routes: [{ name: tabName }] } }],
+    };
+  },
+};
+
 const RootStack = () => {
   return (
-    <NavigationContainer onReady={() => logger.log('NavigationContainer ready')}>
+    <NavigationContainer linking={linking} onReady={() => logger.log('NavigationContainer ready')}>
       <Stack.Navigator>
         <Stack.Screen
           name="MainTabs"


### PR DESCRIPTION
## 요약

위젯을 탭하면 해당 콘텐츠 탭으로 바로 이동하도록 딥링크를 연결했습니다.

- QT 위젯 탭 → 매일 만나 탭
- 설교 위젯 탭 → 주일 말씀 탭
- 유튜브 모드 ON일 때는 기존 동작 유지 (YouTube URL 열기) (iOS는 별도 이슈)

## 구현 방식

URL 스킴 딥링크 사용 (`meditationblossom://open?tab=daily_manna`)

| 플랫폼 | 변경 내용 |
|---|---|
| RN | NavigationContainer에 linking 설정 추가, 쿼리 파라미터 파싱 후 탭 이동 |
| Android | AndroidManifest.xml URL 스킴 등록, 위젯별 딥링크 URL 분기 |
| iOS | Info.plist URL 스킴 등록, .widgetURL() 추가 |

## 테스트

```bash
# Android
adb shell am start -a android.intent.action.VIEW -d "meditationblossom://open?tab=daily_manna"
adb shell am start -a android.intent.action.VIEW -d "meditationblossom://open?tab=sunday_sermon"

# iOS
xcrun simctl openurl booted "meditationblossom://open?tab=daily_manna"
xcrun simctl openurl booted "meditationblossom://open?tab=sunday_sermon"
```

- [x] Android 딥링크 동작 확인
- [x] iOS 딥링크 동작 확인
- [x] 유튜브 모드 ON/OFF 동작 시 Android 딥링크 동작 확인

## 참고
- YoutubeLinkClickAction 클래스명이 역할과 맞지 않아 리네임 필요
- Android/iOS/RN 딥링크 URL 상수가 각 플랫폼에 분산되어 있으므로 변경 시 세 곳 모두 수정 필요