### PR TITLE
[ISSUE-60] iOS 위젯 유튜브 이동 설정값 App Group UserDefaults에 저장

### DIFF
--- a/ios/MeditationBlossomWidget/MeditationBlossomWidget.swift
+++ b/ios/MeditationBlossomWidget/MeditationBlossomWidget.swift
@@ -15,18 +15,32 @@ private enum WidgetConstants {
   static let appGroupId = "group.mannachurch.meditationblossom"
   static let displaySermonKey = "displaySermon"
   static let fcmSermonKey = "fcm_sermon"
+  static let youtubeLinkEnabledKey = "youtube_link_enabled"
+  static let fallbackYoutubeUrl = URL(string: "https://www.youtube.com/@만나")!
   static let widgetKind = "MeditationBlossomWidget"
   static let deepLinkSundaySermon = URL(string: "meditationblossom://open?tab=sunday_sermon")!
 }
 
 struct SimpleEntry: TimelineEntry {
-  let date: Date;
-  let title: String;
-  let quote: String;
-  let verse: String;
+  let date: Date
+  let title: String
+  let quote: String
+  let verse: String
+  let videoUrl: String?
+  let youtubeLinkEnabled: Bool
+
+  var targetURL: URL {
+    if youtubeLinkEnabled {
+      if let urlStr = videoUrl, let url = URL(string: urlStr) {
+        return url
+      }
+      return WidgetConstants.fallbackYoutubeUrl
+    }
+    return WidgetConstants.deepLinkSundaySermon
+  }
 }
 
-private let emptyEntry = SimpleEntry(date: Date(), title: " ", quote: "등록된 설교가 없습니다", verse: " ")
+private let emptyEntry = SimpleEntry(date: Date(), title: " ", quote: "등록된 설교가 없습니다", verse: " ", videoUrl: nil, youtubeLinkEnabled: false)
 
 @available(iOS 16.0, *)
 struct Provider: TimelineProvider {
@@ -132,7 +146,9 @@ struct Provider: TimelineProvider {
       }
     }
 
-    return SimpleEntry(date: Date(), title: sermon.title, quote: quote, verse: verse)
+    let youtubeLinkEnabled = sharedDefaults.bool(forKey: WidgetConstants.youtubeLinkEnabledKey)
+
+    return SimpleEntry(date: Date(), title: sermon.title, quote: quote, verse: verse, videoUrl: sermon.videoUrl, youtubeLinkEnabled: youtubeLinkEnabled)
   }
 }
 
@@ -145,11 +161,11 @@ struct MeditationBlossomWidget: Widget {
       if #available(iOS 17.0, *) {
         MeditationBlossomWidgetEntryView(entry: entry)
           .containerBackground(.fill.tertiary, for: .widget)
-          .widgetURL(WidgetConstants.deepLinkSundaySermon)
+          .widgetURL(entry.targetURL)
       } else {
         // iOS 16에서는 View 자체에 배경 적용
         MeditationBlossomWidgetEntryView(entry: entry)
-          .widgetURL(WidgetConstants.deepLinkSundaySermon)
+          .widgetURL(entry.targetURL)
       }
     }
     .supportedFamilies([.systemMedium, .systemLarge])

--- a/ios/MeditationBlossomWidget/Sermon.swift
+++ b/ios/MeditationBlossomWidget/Sermon.swift
@@ -20,18 +20,18 @@ struct Sermon: Codable {
     let dayOfWeek: String? // Optional + 이름 변경
     let createdAt: FirestoreTimeStamp? // 이름 변경
     let updatedAt: FirestoreTimeStamp? // 이름 변경
+    let videoUrl: String? // 유튜브 영상 URL (optional)
 
-    // JSON의 키 이름과 Swift 구조체의 프로퍼티 이름을 매핑합니다.
-    // 이름이 동일한 경우는 생략해도 되지만, 명시적으로 모두 작성하는 것이 좋습니다.
     enum CodingKeys: String, CodingKey {
         case id, title, content, date, category
         case dayOfWeek = "day_of_week"
         case createdAt = "created_at"
         case updatedAt = "updated_at"
+        case videoUrl = "video_url"
     }
 
     // 기본 초기화 (PushNotificationService에서 사용)
-    init(id: String, title: String, content: String, date: String, category: String?, dayOfWeek: String?, createdAt: FirestoreTimeStamp?, updatedAt: FirestoreTimeStamp?) {
+    init(id: String, title: String, content: String, date: String, category: String?, dayOfWeek: String?, createdAt: FirestoreTimeStamp?, updatedAt: FirestoreTimeStamp?, videoUrl: String? = nil) {
         self.id = id
         self.title = title
         self.content = content
@@ -40,6 +40,7 @@ struct Sermon: Codable {
         self.dayOfWeek = dayOfWeek
         self.createdAt = createdAt
         self.updatedAt = updatedAt
+        self.videoUrl = videoUrl
     }
 
     // ISO 문자열을 Firestore 타임스탬프로 변환하는 커스텀 디코딩
@@ -52,6 +53,7 @@ struct Sermon: Codable {
         date = try container.decode(String.self, forKey: .date)
         category = try container.decodeIfPresent(String.self, forKey: .category)
         dayOfWeek = try container.decodeIfPresent(String.self, forKey: .dayOfWeek)
+        videoUrl = try container.decodeIfPresent(String.self, forKey: .videoUrl)
 
         // createdAt 처리: ISO 문자열 또는 Firestore 타임스탬프
         if let createdAtString = try? container.decode(String.self, forKey: .createdAt) {

--- a/ios/WidgetUpdateModule.swift
+++ b/ios/WidgetUpdateModule.swift
@@ -101,13 +101,22 @@ class WidgetUpdateModule: NSObject {
 
   @objc
   func getYoutubeLinkEnabled(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
-    let enabled = UserDefaults.standard.bool(forKey: Constants.youtubeLinkEnabledKey)
+    guard let sharedDefaults = Self.appGroupDefaults() else {
+      reject("APP_GROUP_ERROR", "App Group을 찾을 수 없습니다.", nil)
+      return
+    }
+    let enabled = sharedDefaults.bool(forKey: Constants.youtubeLinkEnabledKey)
     resolve(enabled)
   }
 
   @objc
   func setYoutubeLinkEnabled(_ enabled: Bool, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
-    UserDefaults.standard.set(enabled, forKey: Constants.youtubeLinkEnabledKey)
+    guard let sharedDefaults = Self.appGroupDefaults() else {
+      reject("APP_GROUP_ERROR", "App Group을 찾을 수 없습니다.", nil)
+      return
+    }
+    sharedDefaults.set(enabled, forKey: Constants.youtubeLinkEnabledKey)
+    WidgetCenter.shared.reloadAllTimelines()
     resolve(nil)
   }
 


### PR DESCRIPTION
## Summary

- **`ios/WidgetUpdateModule.swift`**: `get/setYoutubeLinkEnabled`를 `UserDefaults.standard` → App Group UserDefaults로 교체. 위젯 Extension이 샌드박스 제약으로 앱의 `UserDefaults.standard`를 읽지 못하는 문제 수정. `setYoutubeLinkEnabled` 호출 시 `WidgetCenter.reloadAllTimelines()` 추가하여 설정 변경 즉시 위젯 반영.
- **`ios/MeditationBlossomWidget/Sermon.swift`**: `video_url` 필드 추가 — 위젯이 설교별 YouTube URL을 읽어 클릭 목적지로 사용하기 위함.
- **`ios/MeditationBlossomWidget/MeditationBlossomWidget.swift`**: `SimpleEntry`에 `videoUrl`, `youtubeLinkEnabled` 추가. `targetURL` computed property로 설정값에 따라 YouTube URL 또는 앱 딥링크로 분기.

## Test plan

- [ ] 설정 화면에서 "유튜브 이동" ON → 위젯 탭 시 YouTube로 이동 확인
- [ ] 설정 화면에서 "유튜브 이동" OFF → 위젯 탭 시 앱 주일말씀 탭으로 이동 확인
- [ ] 설정 변경 즉시 위젯 UI 갱신 확인 (WidgetCenter reload)
- [ ] 설교 데이터에 `video_url` 없을 때 fallback URL(`https://www.youtube.com/@만나`) 사용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)