### PR TITLE
[ISSUE-57] iOS 매일만나 위젯 2종 구현 (말씀 / 묵상질문)

### DIFF
--- a/ios/MeditationBlossomWidget/DailyMannaWidget.swift
+++ b/ios/MeditationBlossomWidget/DailyMannaWidget.swift
@@ -1,0 +1,456 @@
+//
+//  DailyMannaWidget.swift
+//  MeditationBlossomWidget
+//
+//  Created by 최상준 on 5/31/25.
+//
+
+import WidgetKit
+import SwiftUI
+import Foundation
+
+// MARK: - Constants
+
+private enum DailyMannaWidgetConstants {
+  static let appGroupId = "group.mannachurch.meditationblossom"
+  static let fcmQtKey = "fcm_qt"
+  static let youtubeLinkEnabledKey = "youtube_link_enabled"
+  static let fallbackYoutubeUrl = URL(string: "https://www.youtube.com/@만나")!
+  static let deepLinkDailyManna = URL(string: "meditationblossom://open?tab=daily_manna")!
+  static let contentWidgetKind = "DailyMannaContentWidget"
+  static let meditationWidgetKind = "DailyMannaMeditationWidget"
+}
+
+// MARK: - Timeline Entry
+
+struct QTEntry: TimelineEntry {
+  let date: Date
+  let mergedTitle: String
+  let dateLabel: String
+  let reference: String      // 성경 본문 참조 (예: "에베소서 5:15-16")
+  let verses: [String]       // 파싱된 구절 목록
+  let meditationQuestions: [String]
+  let isSunday: Bool
+  let videoUrl: String?
+  let youtubeLinkEnabled: Bool
+
+  var targetURL: URL {
+    if youtubeLinkEnabled {
+      if let urlStr = videoUrl, let url = URL(string: urlStr) {
+        return url
+      }
+      return DailyMannaWidgetConstants.fallbackYoutubeUrl
+    }
+    return DailyMannaWidgetConstants.deepLinkDailyManna
+  }
+}
+
+private let emptyQTEntry = QTEntry(
+  date: Date(),
+  mergedTitle: " ",
+  dateLabel: " ",
+  reference: " ",
+  verses: ["등록된 QT가 없습니다"],
+  meditationQuestions: [],
+  isSunday: false,
+  videoUrl: nil,
+  youtubeLinkEnabled: false
+)
+
+// MARK: - Verse Parser
+
+/// 성경 본문에서 책/장/절 참조와 구절 텍스트를 파싱
+private func parseQTContent(_ content: String) -> (reference: String, verses: [String]) {
+  let bookNamePattern = #"(본문\s*[:：]?\s*)?([^\d\s]+ ?\d+:\d+(?:-\d+)?(?:,\s*[^\d\s]+ ?\d+:\d+(?:-\d+)?)*)"#
+
+  guard let bookNameRegex = try? NSRegularExpression(pattern: bookNamePattern, options: []),
+        let match = bookNameRegex.firstMatch(
+          in: content, options: [],
+          range: NSRange(content.startIndex..., in: content))
+  else {
+    return (reference: "", verses: content.isEmpty ? [] : [content])
+  }
+
+  var reference = ""
+  if let refRange = Range(match.range(at: 2), in: content) {
+    reference = String(content[refRange]).trimmingCharacters(in: .whitespaces)
+  }
+
+  let contentStartIndex = content.index(
+    content.startIndex, offsetBy: match.range.location + match.range.length)
+  let contentAfterRef = String(content[contentStartIndex...])
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+
+  guard !contentAfterRef.isEmpty else {
+    return (reference: reference, verses: [])
+  }
+
+  // 구절 번호로 분리
+  let versePattern = #"\d+"#
+  guard let verseRegex = try? NSRegularExpression(pattern: versePattern, options: []) else {
+    return (reference: reference, verses: [contentAfterRef])
+  }
+
+  let verseMatches = verseRegex.matches(
+    in: contentAfterRef, options: [],
+    range: NSRange(contentAfterRef.startIndex..., in: contentAfterRef))
+
+  guard !verseMatches.isEmpty else {
+    return (reference: reference, verses: [contentAfterRef])
+  }
+
+  var verses: [String] = []
+  for i in 0..<verseMatches.count {
+    let currentMatch = verseMatches[i]
+    guard let currentRange = Range(currentMatch.range, in: contentAfterRef) else { continue }
+    let verseEndIndex = currentRange.upperBound
+
+    let verseText: String
+    if i < verseMatches.count - 1,
+       let nextRange = Range(verseMatches[i + 1].range, in: contentAfterRef) {
+      verseText = String(contentAfterRef[verseEndIndex..<nextRange.lowerBound])
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    } else {
+      verseText = String(contentAfterRef[verseEndIndex...])
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    let verseNumber = String(contentAfterRef[currentRange])
+    verses.append("\(verseNumber) \(verseText)")
+  }
+
+  return (reference: reference, verses: verses)
+}
+
+// MARK: - Timeline Provider
+
+@available(iOS 16.0, *)
+struct QTProvider: TimelineProvider {
+  func placeholder(in context: Context) -> QTEntry {
+    emptyQTEntry
+  }
+
+  func getSnapshot(in context: Context, completion: @escaping (QTEntry) -> Void) {
+    completion(createQTEntry())
+  }
+
+  func getTimeline(in context: Context, completion: @escaping (Timeline<QTEntry>) -> Void) {
+    let entry = createQTEntry()
+    let nextUpdateDate = Date().addingTimeInterval(24 * 60 * 60)
+    let timeline = Timeline(entries: [entry], policy: .after(nextUpdateDate))
+    completion(timeline)
+  }
+
+  private func createQTEntry() -> QTEntry {
+    guard let sharedDefaults = UserDefaults(suiteName: DailyMannaWidgetConstants.appGroupId) else {
+      NSLog("DailyMannaWidget: Failed to access App Group UserDefaults")
+      return emptyQTEntry
+    }
+
+    guard let qt: QT = sharedDefaults.getObjectFromString(
+      forKey: DailyMannaWidgetConstants.fcmQtKey, castTo: QT.self)
+    else {
+      NSLog("DailyMannaWidget: No QT data in App Group")
+      return emptyQTEntry
+    }
+
+    NSLog("DailyMannaWidget: Found QT - %@ (ID: %@)", qt.title, qt.id)
+
+    let (reference, verses) = parseQTContent(qt.content)
+    let youtubeLinkEnabled = sharedDefaults.bool(
+      forKey: DailyMannaWidgetConstants.youtubeLinkEnabledKey)
+
+    return QTEntry(
+      date: Date(),
+      mergedTitle: qt.mergedTitle,
+      dateLabel: qt.dateLabel,
+      reference: reference,
+      verses: verses.isEmpty ? [qt.content] : verses,
+      meditationQuestions: qt.meditationQuestions,
+      isSunday: qt.isSunday,
+      videoUrl: qt.videoUrl,
+      youtubeLinkEnabled: youtubeLinkEnabled
+    )
+  }
+}
+
+// MARK: - Content Widget (말씀 위젯)
+
+struct DailyMannaContentWidget: Widget {
+  let kind: String = DailyMannaWidgetConstants.contentWidgetKind
+
+  var body: some WidgetConfiguration {
+    StaticConfiguration(kind: kind, provider: QTProvider()) { entry in
+      if #available(iOS 17.0, *) {
+        DailyMannaContentEntryView(entry: entry)
+          .containerBackground(.fill.tertiary, for: .widget)
+          .widgetURL(entry.targetURL)
+      } else {
+        DailyMannaContentEntryView(entry: entry)
+          .widgetURL(entry.targetURL)
+      }
+    }
+    .configurationDisplayName("매일만나 말씀")
+    .description("오늘의 QT 말씀을 홈 화면에서 바로 확인하세요.")
+    .supportedFamilies([.systemMedium, .systemLarge])
+  }
+}
+
+// MARK: - Content Widget View
+
+struct DailyMannaContentEntryView: View {
+  var entry: QTEntry
+  @Environment(\.widgetFamily) var family
+
+  var body: some View {
+    Group {
+      switch family {
+      case .systemLarge:
+        largeView
+      default:
+        mediumView
+      }
+    }
+    .qtWidgetBackground(Color.clear)
+  }
+
+  // Large: 날짜 + 제목 + 본문 참조 + 구절 텍스트 (최대 5줄)
+  private var largeView: some View {
+    ZStack(alignment: .topLeading) {
+      Image("background_364_382")
+        .resizable()
+        .frame(width: 364, height: 382)
+
+      VStack(alignment: .leading, spacing: 0) {
+        if !entry.dateLabel.trimmingCharacters(in: .whitespaces).isEmpty {
+          Text(entry.dateLabel)
+            .font(.system(size: 13))
+            .foregroundColor(.black.opacity(0.6))
+            .padding(.top, 30)
+            .padding(.leading, 30)
+        }
+
+        Text(entry.mergedTitle)
+          .font(.system(size: 18, weight: .bold))
+          .foregroundColor(.black)
+          .lineLimit(2)
+          .padding(.top, entry.dateLabel.trimmingCharacters(in: .whitespaces).isEmpty ? 30 : 6)
+          .padding(.leading, 30)
+          .padding(.trailing, 30)
+
+        if !entry.reference.trimmingCharacters(in: .whitespaces).isEmpty {
+          Text(entry.reference)
+            .font(.system(size: 13))
+            .foregroundColor(.black.opacity(0.6))
+            .padding(.top, 10)
+            .padding(.leading, 30)
+        }
+
+        Text(entry.verses.joined(separator: "\n\n"))
+          .font(.system(size: 16, weight: .semibold))
+          .foregroundColor(.black)
+          .lineLimit(6)
+          .padding(.top, 10)
+          .padding(.leading, 30)
+          .padding(.trailing, 30)
+
+        Spacer()
+      }
+    }
+  }
+
+  // Medium: 제목 + 구절 (간결하게)
+  private var mediumView: some View {
+    ZStack {
+      Image("background_364_170")
+        .resizable()
+        .frame(width: 364, height: 170)
+
+      VStack(alignment: .leading, spacing: 4) {
+        Text(entry.mergedTitle)
+          .font(.system(size: 14, weight: .bold))
+          .foregroundColor(.black)
+          .lineLimit(1)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding(.horizontal, 20)
+
+        if !entry.reference.trimmingCharacters(in: .whitespaces).isEmpty {
+          Text(entry.reference)
+            .font(.system(size: 12))
+            .foregroundColor(.black.opacity(0.6))
+            .lineLimit(1)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 20)
+        }
+
+        Text(entry.verses.joined(separator: " "))
+          .font(.system(size: 16, weight: .semibold))
+          .foregroundColor(.black)
+          .lineLimit(4)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding(.horizontal, 20)
+      }
+    }
+  }
+}
+
+// MARK: - Meditation Widget (묵상질문 위젯)
+
+struct DailyMannaMeditationWidget: Widget {
+  let kind: String = DailyMannaWidgetConstants.meditationWidgetKind
+
+  var body: some WidgetConfiguration {
+    StaticConfiguration(kind: kind, provider: QTProvider()) { entry in
+      if #available(iOS 17.0, *) {
+        DailyMannaMeditationEntryView(entry: entry)
+          .containerBackground(.fill.tertiary, for: .widget)
+          .widgetURL(entry.targetURL)
+      } else {
+        DailyMannaMeditationEntryView(entry: entry)
+          .widgetURL(entry.targetURL)
+      }
+    }
+    .configurationDisplayName("매일만나 묵상질문")
+    .description("오늘의 QT 묵상질문을 홈 화면에서 바로 확인하세요.")
+    .supportedFamilies([.systemMedium, .systemLarge])
+  }
+}
+
+// MARK: - Meditation Widget View
+
+struct DailyMannaMeditationEntryView: View {
+  var entry: QTEntry
+  @Environment(\.widgetFamily) var family
+
+  /// 묵상 질문이 없거나 일요일인 경우
+  private var noQuestionsMessage: String {
+    "오늘은 묵상 질문이 없습니다"
+  }
+
+  private var hasQuestions: Bool {
+    !entry.isSunday && !entry.meditationQuestions.isEmpty
+  }
+
+  var body: some View {
+    Group {
+      switch family {
+      case .systemLarge:
+        largeView
+      default:
+        mediumView
+      }
+    }
+    .qtWidgetBackground(Color.clear)
+  }
+
+  // Large: 날짜 + 제목 + 묵상질문 목록 (bullet)
+  private var largeView: some View {
+    ZStack(alignment: .topLeading) {
+      Image("background_364_382")
+        .resizable()
+        .frame(width: 364, height: 382)
+
+      VStack(alignment: .leading, spacing: 0) {
+        if !entry.dateLabel.trimmingCharacters(in: .whitespaces).isEmpty {
+          Text(entry.dateLabel)
+            .font(.system(size: 13))
+            .foregroundColor(.black.opacity(0.6))
+            .padding(.top, 30)
+            .padding(.leading, 30)
+        }
+
+        Text(entry.mergedTitle)
+          .font(.system(size: 18, weight: .bold))
+          .foregroundColor(.black)
+          .lineLimit(2)
+          .padding(.top, entry.dateLabel.trimmingCharacters(in: .whitespaces).isEmpty ? 30 : 6)
+          .padding(.leading, 30)
+          .padding(.trailing, 30)
+
+        Spacer().frame(height: 12)
+
+        Text("묵상 질문")
+          .font(.system(size: 13))
+          .foregroundColor(.black.opacity(0.6))
+          .padding(.leading, 30)
+
+        Spacer().frame(height: 8)
+
+        if hasQuestions {
+          VStack(alignment: .leading, spacing: 8) {
+            ForEach(Array(entry.meditationQuestions.prefix(5).enumerated()), id: \.offset) { _, q in
+              Text("• \(q)")
+                .font(.system(size: 15))
+                .foregroundColor(.black)
+                .lineLimit(2)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 30)
+            }
+          }
+        } else {
+          Text(noQuestionsMessage)
+            .font(.system(size: 15))
+            .foregroundColor(.black.opacity(0.6))
+            .padding(.leading, 30)
+        }
+
+        Spacer()
+      }
+    }
+  }
+
+  // Medium: 제목 + 첫 번째 질문 (간결하게)
+  private var mediumView: some View {
+    ZStack {
+      Image("background_364_170")
+        .resizable()
+        .frame(width: 364, height: 170)
+
+      VStack(alignment: .leading, spacing: 6) {
+        HStack {
+          Text("묵상 질문")
+            .font(.system(size: 12))
+            .foregroundColor(.black.opacity(0.6))
+          Spacer()
+          Text(entry.mergedTitle)
+            .font(.system(size: 12, weight: .bold))
+            .foregroundColor(.black)
+            .lineLimit(1)
+        }
+        .padding(.horizontal, 20)
+
+        if hasQuestions {
+          VStack(alignment: .leading, spacing: 6) {
+            ForEach(Array(entry.meditationQuestions.prefix(3).enumerated()), id: \.offset) { _, q in
+              Text("• \(q)")
+                .font(.system(size: 15))
+                .foregroundColor(.black)
+                .lineLimit(2)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+          }
+          .padding(.horizontal, 20)
+        } else {
+          Text(noQuestionsMessage)
+            .font(.system(size: 15))
+            .foregroundColor(.black.opacity(0.6))
+            .padding(.horizontal, 20)
+        }
+      }
+    }
+  }
+}
+
+// MARK: - Background Modifier (iOS 16 호환)
+
+extension View {
+  func qtWidgetBackground(_ color: Color) -> some View {
+    if #available(iOS 17.0, *) {
+      return AnyView(self.containerBackground(for: .widget) {
+        color
+      })
+    } else {
+      return AnyView(self.background(color))
+    }
+  }
+}

--- a/ios/MeditationBlossomWidget/MeditationBlossomWidgetBundle.swift
+++ b/ios/MeditationBlossomWidget/MeditationBlossomWidgetBundle.swift
@@ -12,6 +12,8 @@ import SwiftUI
 struct MeditationBlossomWidgetBundle: WidgetBundle {
     var body: some Widget {
         MeditationBlossomWidget()
+        DailyMannaContentWidget()
+        DailyMannaMeditationWidget()
         // MeditationBlossomWidgetControl() - iOS 18.0+ 전용 기능이므로 주석 처리
         MeditationBlossomWidgetLiveActivity()
     }

--- a/ios/MeditationBlossomWidget/QT.swift
+++ b/ios/MeditationBlossomWidget/QT.swift
@@ -1,0 +1,93 @@
+//
+//  QT.swift
+//  MeditationBlossomWidget
+//
+//  Created by 최상준 on 5/31/25.
+//
+
+import Foundation
+
+struct QT: Codable {
+  let id: String
+  let title: String
+  let seriesTitle: String
+  let content: String
+  let date: String
+  let dayOfWeek: String?
+  let videoUrl: String?
+  let meditationQuestions: [String]
+
+  enum CodingKeys: String, CodingKey {
+    case id, title, content, date
+    case seriesTitle = "series_title"
+    case dayOfWeek = "day_of_week"
+    case videoUrl = "video_url"
+    case meditationQuestions = "meditation_questions"
+  }
+
+  init(id: String, title: String, seriesTitle: String, content: String, date: String,
+       dayOfWeek: String?, videoUrl: String?, meditationQuestions: [String]) {
+    self.id = id
+    self.title = title
+    self.seriesTitle = seriesTitle
+    self.content = content
+    self.date = date
+    self.dayOfWeek = dayOfWeek
+    self.videoUrl = videoUrl
+    self.meditationQuestions = meditationQuestions
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(String.self, forKey: .id)
+    title = try container.decode(String.self, forKey: .title)
+    seriesTitle = (try? container.decode(String.self, forKey: .seriesTitle)) ?? ""
+    content = try container.decode(String.self, forKey: .content)
+    date = (try? container.decode(String.self, forKey: .date)) ?? ""
+    dayOfWeek = try? container.decode(String.self, forKey: .dayOfWeek)
+    videoUrl = try? container.decode(String.self, forKey: .videoUrl)
+    // meditation_questions는 string 배열로 저장 (useQtWidgetSync에서 파싱 후 저장)
+    meditationQuestions = (try? container.decode([String].self, forKey: .meditationQuestions)) ?? []
+  }
+
+  /// 화면에 표시할 병합 제목 (예: "QT제목 / 시리즈제목")
+  var mergedTitle: String {
+    if seriesTitle.isEmpty { return title }
+    return "\(title) / \(seriesTitle)"
+  }
+
+  /// 요일 한글 변환
+  var dayOfWeekKorean: String? {
+    let map: [String: String] = [
+      "MON": "월", "TUE": "화", "WED": "수", "THU": "목",
+      "FRI": "금", "SAT": "토", "SUN": "일",
+    ]
+    guard let dow = dayOfWeek else { return nil }
+    return map[dow.uppercased()]
+  }
+
+  /// 날짜 레이블 (예: "4월 26일 · 화")
+  var dateLabel: String {
+    let inputFormatter = DateFormatter()
+    inputFormatter.dateFormat = "yyyy-MM-dd"
+    inputFormatter.locale = Locale(identifier: "ko_KR")
+
+    let outputFormatter = DateFormatter()
+    outputFormatter.dateFormat = "M월 d일"
+    outputFormatter.locale = Locale(identifier: "ko_KR")
+
+    guard let parsedDate = inputFormatter.date(from: date) else {
+      return dayOfWeekKorean ?? ""
+    }
+    let dateStr = outputFormatter.string(from: parsedDate)
+    if let dow = dayOfWeekKorean {
+      return "\(dateStr) · \(dow)"
+    }
+    return dateStr
+  }
+
+  /// 일요일 여부
+  var isSunday: Bool {
+    return dayOfWeek?.uppercased() == "SUN"
+  }
+}

--- a/ios/meditation_blossom.xcodeproj/project.pbxproj
+++ b/ios/meditation_blossom.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		3595A30E2DEBF76F006716D8 /* MeditationBlossomWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3595A3062DEBF76F006716D8 /* MeditationBlossomWidget.swift */; };
 		3595A30F2DEBF76F006716D8 /* MeditationBlossomWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3595A3072DEBF76F006716D8 /* MeditationBlossomWidgetBundle.swift */; };
 		3595A3112DEBF76F006716D8 /* MeditationBlossomWidgetLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3595A3092DEBF76F006716D8 /* MeditationBlossomWidgetLiveActivity.swift */; };
+		35570001BBBB0001BBBBBBBB /* QT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35570000BBBB0001BBBBBBBB /* QT.swift */; };
+		35570003BBBB0001BBBBBBBB /* DailyMannaWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35570002BBBB0001BBBBBBBB /* DailyMannaWidget.swift */; };
 		35A491452F87753200666495 /* SermonBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 35A491442F87753200666495 /* SermonBuilder.m */; };
 		35A99CA72E5F502B0087CB5B /* Sermon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35B6CFCE2E01AC0A004A13DD /* Sermon.swift */; };
 		35B6CFCF2E01AC0E004A13DD /* Sermon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35B6CFCE2E01AC0A004A13DD /* Sermon.swift */; };
@@ -115,6 +117,8 @@
 		3595A3062DEBF76F006716D8 /* MeditationBlossomWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeditationBlossomWidget.swift; sourceTree = "<group>"; };
 		3595A3072DEBF76F006716D8 /* MeditationBlossomWidgetBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeditationBlossomWidgetBundle.swift; sourceTree = "<group>"; };
 		3595A3092DEBF76F006716D8 /* MeditationBlossomWidgetLiveActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeditationBlossomWidgetLiveActivity.swift; sourceTree = "<group>"; };
+		35570000BBBB0001BBBBBBBB /* QT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QT.swift; sourceTree = "<group>"; };
+		35570002BBBB0001BBBBBBBB /* DailyMannaWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyMannaWidget.swift; sourceTree = "<group>"; };
 		35A491432F87753200666495 /* SermonBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = meditation_blossom/SermonBuilder.h; sourceTree = "<group>"; };
 		35A491442F87753200666495 /* SermonBuilder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = meditation_blossom/SermonBuilder.m; sourceTree = "<group>"; };
 		35B6CFCE2E01AC0A004A13DD /* Sermon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sermon.swift; sourceTree = "<group>"; };
@@ -258,11 +262,13 @@
 			isa = PBXGroup;
 			children = (
 				35B6CFCE2E01AC0A004A13DD /* Sermon.swift */,
+				35570000BBBB0001BBBBBBBB /* QT.swift */,
 				3595A3042DEBF76F006716D8 /* Assets.xcassets */,
 				3595A3052DEBF76F006716D8 /* Info.plist */,
 				3595A3062DEBF76F006716D8 /* MeditationBlossomWidget.swift */,
 				3595A3072DEBF76F006716D8 /* MeditationBlossomWidgetBundle.swift */,
 				3595A3092DEBF76F006716D8 /* MeditationBlossomWidgetLiveActivity.swift */,
+				35570002BBBB0001BBBBBBBB /* DailyMannaWidget.swift */,
 			);
 			path = MeditationBlossomWidget;
 			sourceTree = "<group>";
@@ -781,6 +787,8 @@
 				3595A30F2DEBF76F006716D8 /* MeditationBlossomWidgetBundle.swift in Sources */,
 				3595A3112DEBF76F006716D8 /* MeditationBlossomWidgetLiveActivity.swift in Sources */,
 				35B6CFCF2E01AC0E004A13DD /* Sermon.swift in Sources */,
+				35570001BBBB0001BBBBBBBB /* QT.swift in Sources */,
+				35570003BBBB0001BBBBBBBB /* DailyMannaWidget.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Summary

- `QT.swift`: WidgetKit Extension용 QT 데이터 모델 추가 — App Group `fcm_qt` 키에서 JSON 역직렬화
- `DailyMannaWidget.swift`: 매일만나 말씀 + 묵상질문 위젯 구현
  - **DailyMannaContentWidget**: 날짜 레이블 · 제목 · 성경 본문 참조 · 구절 텍스트 표시 (medium / large)
  - **DailyMannaMeditationWidget**: 묵상질문 bullet 목록 표시; 일요일이거나 질문이 없을 때 "오늘은 묵상 질문이 없습니다" 메시지 표시 (medium / large)
  - `youtube_link_enabled` App Group 설정에 따라 YouTube URL 또는 `meditationblossom://open?tab=daily_manna` 딥링크로 이동
- `MeditationBlossomWidgetBundle.swift`: 두 새 위젯을 `@main` 번들에 등록
- `project.pbxproj`: 신규 Swift 파일을 MeditationBlossomWidgetExtension 타겟에 추가

## Test plan

- [ ] Xcode에서 MeditationBlossomWidgetExtension 빌드 확인
- [ ] 시뮬레이터에서 위젯 추가 — "매일만나 말씀" · "매일만나 묵상질문" 위젯이 선택 목록에 표시되는지 확인
- [ ] App Group `fcm_qt`에 데이터가 있을 때 위젯에 말씀/묵상질문이 표시되는지 확인
- [ ] 일요일 데이터(`day_of_week: "SUN"`)에서 묵상질문 위젯에 안내 메시지 표시 확인
- [ ] `youtube_link_enabled = true`일 때 위젯 탭 → YouTube로 이동 확인
- [ ] `youtube_link_enabled = false`일 때 위젯 탭 → DailyMannaScreen 딥링크 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)