### PR TITLE
[ISSUE-124] About this app 섹션 레이아웃 개선 및 미니프로젝트 링크 업데이트

### DIFF
--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -245,7 +245,8 @@ const SettingsScreen = ({ navigation }: Props) => {
           )}
         </View>
 
-        {/* About this app — 스크롤 내부, 하단 */}
+        <View style={styles.aboutSpacer} />
+        {/* About this app — 콘텐츠가 짧으면 화면 하단 고정, 길면 스크롤 끝 */}
         <View style={styles.aboutSection}>
           <Text style={styles.aboutTitle}>About this app</Text>
           <Text style={styles.aboutText}>묵상만개 Meditation Blossom</Text>
@@ -292,7 +293,10 @@ const styles = StyleSheet.create({
     letterSpacing: -1,
   },
   scrollContent: {
-    paddingBottom: 40,
+    flexGrow: 1,
+  },
+  aboutSpacer: {
+    flex: 1,
   },
   sectionLabel: {
     color: '#49454F',

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -244,21 +244,21 @@ const SettingsScreen = ({ navigation }: Props) => {
             </>
           )}
         </View>
-      </ScrollView>
 
-      {/* About this app — 스크롤 밖, 하단 고정 */}
-      <View style={styles.aboutSection}>
-        <Text style={styles.aboutTitle}>About this app</Text>
-        <Text style={styles.aboutText}>묵상만개 Meditation Blossom</Text>
-        <TouchableOpacity onPress={() => Linking.openURL('https://manna.or.kr/somoim/157228/')}>
-          <Text style={styles.aboutText}>from 2025 만개하다 미니프로젝트 - 앱 만들기</Text>
-        </TouchableOpacity>
-        <TouchableOpacity onPress={() => Linking.openURL('https://manna.or.kr/somoim/130539/')}>
-          <Text style={styles.aboutText}>개발 : 만개하다 - 만나교회 개발자 모임</Text>
-        </TouchableOpacity>
-        <Text style={styles.aboutText}>디자인 : Somang Choi</Text>
-        <Text style={styles.aboutText}>버전 : {DeviceInfo.getVersion()}</Text>
-      </View>
+        {/* About this app — 스크롤 내부, 하단 */}
+        <View style={styles.aboutSection}>
+          <Text style={styles.aboutTitle}>About this app</Text>
+          <Text style={styles.aboutText}>묵상만개 Meditation Blossom</Text>
+          <TouchableOpacity onPress={() => Linking.openURL('https://manna.or.kr/somoim/190510/')}>
+            <Text style={styles.aboutText}>2026 만개하다 미니프로젝트</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={() => Linking.openURL('https://manna.or.kr/somoim/130539/')}>
+            <Text style={styles.aboutText}>개발 : 만개하다 - 만나교회 개발자 모임</Text>
+          </TouchableOpacity>
+          <Text style={styles.aboutText}>디자인 : Somang Choi</Text>
+          <Text style={styles.aboutText}>버전 : {DeviceInfo.getVersion()}</Text>
+        </View>
+      </ScrollView>
     </SafeAreaView>
   );
 };


### PR DESCRIPTION
## Summary

- **About this app 섹션 위치 개선**: 화면 크기에 따라 동적으로 동작하도록 변경
  - 콘텐츠가 짧아 스크롤이 필요 없는 경우 → 화면 하단에 고정
  - 콘텐츠가 길어 스크롤이 필요한 경우 → 스크롤 끝에 위치
- **미니프로젝트 링크 업데이트**
  - 텍스트: `from 2025 만개하다 미니프로젝트 - 앱 만들기` → `2026 만개하다 미니프로젝트`
  - URL: `https://manna.or.kr/somoim/157228/` → `https://manna.or.kr/somoim/190510/`

## 구현 방법

`ScrollView`의 `contentContainerStyle`에 `flexGrow: 1` 적용 + About 섹션 바로 위에 `flex: 1` spacer 추가.
spacer가 남은 공간을 흡수하여 About 섹션을 항상 하단으로 밀어내는 방식.

## Test plan

- [ ] 개발자 메뉴 닫힌 상태 → About 섹션이 화면 하단에 고정되어 보이는지 확인
- [ ] 개발자 메뉴 열린 상태 → 스크롤 내려야 About 섹션이 보이는지 확인
- [ ] 미니프로젝트 링크 탭 시 `https://manna.or.kr/somoim/190510/` 으로 이동하는지 확인

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)