### PR TITLE
[ISSUE-74] iOS bible_references 기반 말씀 본문 조회 완성

### DIFF
--- a/ios/PushNotificationService/NotificationService.swift
+++ b/ios/PushNotificationService/NotificationService.swift
@@ -1,5 +1,6 @@
 import UserNotifications
 import WidgetKit
+import SQLite3 // BibleDbHelper가 사용하는 모듈 (BibleDbHelper.swift가 이 타겟에도 컴파일됨)
 
 class NotificationService: UNNotificationServiceExtension {
 
@@ -123,15 +124,59 @@ class NotificationService: UNNotificationServiceExtension {
 
     // MARK: - Sermon Parsing & Saving
 
+    // MARK: - Bible References
+
+    /// bible_references JSON 배열(서버 snake_case 키)을 DB에서 조회하여 본문 문자열로 반환.
+    /// 빈 배열([]) = 말씀 없는 날 → 빈 문자열 반환.
+    private func resolveBibleReferencesFromUserInfo(_ userInfo: [AnyHashable: Any]) -> String? {
+        guard let topic = userInfo["topic"] as? String else { return nil }
+        let shouldResolve = topic.contains("v2") || topic.contains("qt_events")
+        guard shouldResolve else { return nil }
+
+        // bible_references는 JSON 문자열 또는 이미 파싱된 배열로 도착할 수 있음
+        var refs: [[String: Any]] = []
+        if let rawString = userInfo["bible_references"] as? String,
+           let data = rawString.data(using: .utf8),
+           let parsed = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] {
+            refs = parsed
+        } else if let rawArray = userInfo["bible_references"] as? [[String: Any]] {
+            refs = rawArray
+        }
+
+        var lines: [String] = []
+        for ref in refs {
+            guard let book = ref["book"] as? String,
+                  let chapter = ref["chapter"] as? Int,
+                  let verseStart = ref["verse_start"] as? Int,
+                  let verseEnd = ref["verse_end"] as? Int else { continue }
+            let text = BibleDbHelper.shared.getVerses(book: book, chapter: chapter,
+                                                      verseStart: verseStart, verseEnd: verseEnd)
+            if !text.isEmpty {
+                lines.append(text)
+            }
+        }
+        return lines.joined(separator: "\n\n")
+    }
+
     private func parseSermonFromUserInfo(_ userInfo: [AnyHashable: Any]) -> Sermon? {
         let id = (userInfo["source_id"] as? String) ?? (userInfo["id"] as? String) ?? generateSermonId(from: userInfo)
 
         guard let title = userInfo["title"] as? String,
-              let content = userInfo["content"] as? String,
               let date = userInfo["date"] as? String,
               let dayOfWeek = userInfo["day_of_week"] as? String else {
-            NSLog("NotificationService: parseSermonFromUserInfo failed - missing required fields (title/content/date/day_of_week)")
+            NSLog("NotificationService: parseSermonFromUserInfo failed - missing required fields (title/date/day_of_week)")
             return nil
+        }
+
+        // bible_references에서 본문 조회 시도; 없으면 content 필드 fallback
+        let content: String
+        if let resolved = resolveBibleReferencesFromUserInfo(userInfo) {
+            content = resolved
+        } else if let rawContent = userInfo["content"] as? String {
+            content = rawContent
+        } else {
+            NSLog("NotificationService: parseSermonFromUserInfo - no content or bible_references")
+            content = ""
         }
 
         let category = userInfo["category"] as? String

--- a/ios/WidgetUpdateModule.swift
+++ b/ios/WidgetUpdateModule.swift
@@ -46,10 +46,10 @@ class WidgetUpdateModule: NSObject {
 
   // MARK: - Bible References
 
-  @objc
   // DB 조회를 직렬화하기 위한 전용 큐 (SQLite 멀티스레드 에러 방지)
   private static let dbQueue = DispatchQueue(label: "com.mannachurch.BibleDbHelper", qos: .userInitiated)
 
+  @objc
   func resolveBibleReferences(_ jsonString: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
     NSLog("📖 resolveBibleReferences called, input: %@", String(jsonString.prefix(120)))
     WidgetUpdateModule.dbQueue.async {

--- a/ios/WidgetUpdateModule.swift
+++ b/ios/WidgetUpdateModule.swift
@@ -65,8 +65,9 @@ class WidgetUpdateModule: NSObject {
         for ref in refs {
           guard let book = ref["book"] as? String,
                 let chapter = ref["chapter"] as? Int,
-                let fromVerse = ref["from_verse"] as? Int else { continue }
-          let toVerse = ref["to_verse"] as? Int ?? fromVerse
+                // Firestore/FCM 모두 snake_case 키(verse_start/verse_end) 사용
+                let fromVerse = ref["verse_start"] as? Int else { continue }
+          let toVerse = ref["verse_end"] as? Int ?? fromVerse
 
           let text = helper.getVerses(book: book, chapter: chapter, verseStart: fromVerse, verseEnd: toVerse)
           if !text.isEmpty {

--- a/ios/WidgetUpdateModule.swift
+++ b/ios/WidgetUpdateModule.swift
@@ -47,9 +47,12 @@ class WidgetUpdateModule: NSObject {
   // MARK: - Bible References
 
   @objc
+  // DB 조회를 직렬화하기 위한 전용 큐 (SQLite 멀티스레드 에러 방지)
+  private static let dbQueue = DispatchQueue(label: "com.mannachurch.BibleDbHelper", qos: .userInitiated)
+
   func resolveBibleReferences(_ jsonString: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
-    NSLog("📖 resolveBibleReferences called, input: %@", String(jsonString.prefix(100)))
-    DispatchQueue.global(qos: .userInitiated).async {
+    NSLog("📖 resolveBibleReferences called, input: %@", String(jsonString.prefix(120)))
+    WidgetUpdateModule.dbQueue.async {
       do {
         guard let data = jsonString.data(using: .utf8),
               let refs = try JSONSerialization.jsonObject(with: data) as? [[String: Any]],
@@ -61,27 +64,52 @@ class WidgetUpdateModule: NSObject {
 
         NSLog("📖 resolveBibleReferences: %d refs to process", refs.count)
         let helper = BibleDbHelper.shared
-        var lines: [String] = []
+        var resultParts: [String] = []
 
         for ref in refs {
           guard let book = ref["book"] as? String,
                 let chapter = ref["chapter"] as? Int,
-                // Firestore/FCM 모두 snake_case 키(verse_start/verse_end) 사용
                 let fromVerse = ref["verse_start"] as? Int else {
-            NSLog("📖 resolveBibleReferences: skipping ref with missing keys: %@", ref.description)
+            NSLog("📖 skipping ref with missing book/chapter/verse_start keys")
             continue
           }
           let toVerse = ref["verse_end"] as? Int ?? fromVerse
-          NSLog("📖 querying %@ %d:%d-%d", book, chapter, fromVerse, toVerse)
+          let rangeStr = fromVerse == toVerse ? "\(chapter):\(fromVerse)" : "\(chapter):\(fromVerse)-\(toVerse)"
 
-          let text = helper.getVerses(book: book, chapter: chapter, verseStart: fromVerse, verseEnd: toVerse)
-          NSLog("📖 result: %@", text.isEmpty ? "(empty)" : String(text.prefix(50)))
-          if !text.isEmpty {
-            lines.append(text)
+          // 서버가 verses 배열로 본문을 미리 제공하면 DB 조회 불필요
+          var verseBodyLines: [String] = []
+          if let verses = ref["verses"] as? [[String: Any]], !verses.isEmpty {
+            NSLog("📖 using embedded verses for %@ %@", book, rangeStr)
+            for verse in verses {
+              guard let content = verse["content"] as? String, !content.isEmpty else { continue }
+              if let num = verse["verse_number"] as? Int {
+                verseBodyLines.append("\(num) \(content)")
+              } else {
+                verseBodyLines.append(content)
+              }
+            }
           }
+
+          // embedded verses 없으면 bible.db 직접 조회
+          if verseBodyLines.isEmpty {
+            NSLog("📖 querying DB for %@ %@", book, rangeStr)
+            let text = helper.getVerses(book: book, chapter: chapter, verseStart: fromVerse, verseEnd: toVerse)
+            NSLog("📖 DB result: %@", text.isEmpty ? "(empty)" : String(text.prefix(50)))
+            if !text.isEmpty {
+              verseBodyLines = text.components(separatedBy: "\n").filter { !$0.isEmpty }
+            }
+          }
+
+          if verseBodyLines.isEmpty { continue }
+
+          // Android BibleReferenceResolver와 동일한 포맷:
+          // "본문 : 사무엘상 17:31-37 31 어떤 사람이..."
+          // extractContent(sermonParser.ts)가 이 포맷을 파싱한다.
+          let verseBody = verseBodyLines.joined(separator: " ")
+          resultParts.append("본문 : \(book) \(rangeStr) \(verseBody)")
         }
 
-        let result = lines.joined(separator: "\n\n")
+        let result = resultParts.joined(separator: "\n\n")
         NSLog("📖 resolveBibleReferences done: %d chars", result.count)
         resolve(result)
       } catch {

--- a/ios/WidgetUpdateModule.swift
+++ b/ios/WidgetUpdateModule.swift
@@ -48,17 +48,18 @@ class WidgetUpdateModule: NSObject {
 
   @objc
   func resolveBibleReferences(_ jsonString: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
-    // iOS: JS 코드(QT.ts, Sermon.ts)는 Platform.OS === 'ios' 분기에서 이 함수를 호출하지 않음.
-    // 향후 사용을 위해 BibleDbHelper 를 통해 구현.
+    NSLog("📖 resolveBibleReferences called, input: %@", String(jsonString.prefix(100)))
     DispatchQueue.global(qos: .userInitiated).async {
       do {
         guard let data = jsonString.data(using: .utf8),
               let refs = try JSONSerialization.jsonObject(with: data) as? [[String: Any]],
               !refs.isEmpty else {
-          resolve(jsonString)
+          NSLog("📖 resolveBibleReferences: empty refs or parse failed → returning empty")
+          resolve("")
           return
         }
 
+        NSLog("📖 resolveBibleReferences: %d refs to process", refs.count)
         let helper = BibleDbHelper.shared
         var lines: [String] = []
 
@@ -66,17 +67,25 @@ class WidgetUpdateModule: NSObject {
           guard let book = ref["book"] as? String,
                 let chapter = ref["chapter"] as? Int,
                 // Firestore/FCM 모두 snake_case 키(verse_start/verse_end) 사용
-                let fromVerse = ref["verse_start"] as? Int else { continue }
+                let fromVerse = ref["verse_start"] as? Int else {
+            NSLog("📖 resolveBibleReferences: skipping ref with missing keys: %@", ref.description)
+            continue
+          }
           let toVerse = ref["verse_end"] as? Int ?? fromVerse
+          NSLog("📖 querying %@ %d:%d-%d", book, chapter, fromVerse, toVerse)
 
           let text = helper.getVerses(book: book, chapter: chapter, verseStart: fromVerse, verseEnd: toVerse)
+          NSLog("📖 result: %@", text.isEmpty ? "(empty)" : String(text.prefix(50)))
           if !text.isEmpty {
             lines.append(text)
           }
         }
 
-        resolve(lines.joined(separator: "\n\n"))
+        let result = lines.joined(separator: "\n\n")
+        NSLog("📖 resolveBibleReferences done: %d chars", result.count)
+        resolve(result)
       } catch {
+        NSLog("📖 resolveBibleReferences error: %@", error.localizedDescription)
         reject("BIBLE_RESOLVE_ERROR", error.localizedDescription, error)
       }
     }

--- a/ios/WidgetUpdateModule.swift
+++ b/ios/WidgetUpdateModule.swift
@@ -51,35 +51,28 @@ class WidgetUpdateModule: NSObject {
 
   @objc
   func resolveBibleReferences(_ jsonString: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
-    NSLog("📖 resolveBibleReferences called, input: %@", String(jsonString.prefix(120)))
     WidgetUpdateModule.dbQueue.async {
       do {
         guard let data = jsonString.data(using: .utf8),
               let refs = try JSONSerialization.jsonObject(with: data) as? [[String: Any]],
               !refs.isEmpty else {
-          NSLog("📖 resolveBibleReferences: empty refs or parse failed → returning empty")
           resolve("")
           return
         }
 
-        NSLog("📖 resolveBibleReferences: %d refs to process", refs.count)
         let helper = BibleDbHelper.shared
         var resultParts: [String] = []
 
         for ref in refs {
           guard let book = ref["book"] as? String,
                 let chapter = ref["chapter"] as? Int,
-                let fromVerse = ref["verse_start"] as? Int else {
-            NSLog("📖 skipping ref with missing book/chapter/verse_start keys")
-            continue
-          }
+                let fromVerse = ref["verse_start"] as? Int else { continue }
           let toVerse = ref["verse_end"] as? Int ?? fromVerse
           let rangeStr = fromVerse == toVerse ? "\(chapter):\(fromVerse)" : "\(chapter):\(fromVerse)-\(toVerse)"
 
           // 서버가 verses 배열로 본문을 미리 제공하면 DB 조회 불필요
           var verseBodyLines: [String] = []
           if let verses = ref["verses"] as? [[String: Any]], !verses.isEmpty {
-            NSLog("📖 using embedded verses for %@ %@", book, rangeStr)
             for verse in verses {
               guard let content = verse["content"] as? String, !content.isEmpty else { continue }
               if let num = verse["verse_number"] as? Int {
@@ -92,9 +85,7 @@ class WidgetUpdateModule: NSObject {
 
           // embedded verses 없으면 bible.db 직접 조회
           if verseBodyLines.isEmpty {
-            NSLog("📖 querying DB for %@ %@", book, rangeStr)
             let text = helper.getVerses(book: book, chapter: chapter, verseStart: fromVerse, verseEnd: toVerse)
-            NSLog("📖 DB result: %@", text.isEmpty ? "(empty)" : String(text.prefix(50)))
             if !text.isEmpty {
               verseBodyLines = text.components(separatedBy: "\n").filter { !$0.isEmpty }
             }
@@ -109,11 +100,9 @@ class WidgetUpdateModule: NSObject {
           resultParts.append("본문 : \(book) \(rangeStr) \(verseBody)")
         }
 
-        let result = resultParts.joined(separator: "\n\n")
-        NSLog("📖 resolveBibleReferences done: %d chars", result.count)
-        resolve(result)
+        resolve(resultParts.joined(separator: "\n\n"))
       } catch {
-        NSLog("📖 resolveBibleReferences error: %@", error.localizedDescription)
+        NSLog("resolveBibleReferences error: %@", error.localizedDescription)
         reject("BIBLE_RESOLVE_ERROR", error.localizedDescription, error)
       }
     }

--- a/ios/WidgetUpdateModule.swift
+++ b/ios/WidgetUpdateModule.swift
@@ -59,7 +59,7 @@ class WidgetUpdateModule: NSObject {
           return
         }
 
-        let helper = BibleDbHelper()
+        let helper = BibleDbHelper.shared
         var lines: [String] = []
 
         for ref in refs {

--- a/ios/meditation_blossom.xcodeproj/project.pbxproj
+++ b/ios/meditation_blossom.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		35CF0001AAAA0001AAAAAAAA /* RCTView+ColorFix.m in Sources */ = {isa = PBXBuildFile; fileRef = 35CF0000AAAA0001AAAAAAAA /* RCTView+ColorFix.m */; };
 		35D57CC72E4E12CF006A8872 /* MyEventModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 35D57CC62E4E12C1006A8872 /* MyEventModule.m */; };
 		35DF7D9B2F87741F004FEDA3 /* BibleDbHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DF7D9A2F87741F004FEDA3 /* BibleDbHelper.swift */; };
+		92C5C884FCF54E7ABBCD3904 /* BibleDbHelper.swift in Sources (PushNotificationService) */ = {isa = PBXBuildFile; fileRef = 35DF7D9A2F87741F004FEDA3; };
 		36D0ABAEB660494094DD9C97 /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = F7AF6C1D72CD4A66B58C33B8 /* Pretendard-Bold.otf */; };
 		3C0090A2347247CC84AEF51C /* Pretendard-Thin.otf in Resources */ = {isa = PBXBuildFile; fileRef = FA817E704269452E9C720D87 /* Pretendard-Thin.otf */; };
 		4BF67687D54E4D26AF6361BE /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9C169B17C3504C6E8ED9A33A /* Pretendard-SemiBold.otf */; };
@@ -775,6 +776,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+
+				92C5C884FCF54E7ABBCD3904 /* BibleDbHelper.swift in Sources */,
 				35A99CA72E5F502B0087CB5B /* Sermon.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/meditation_blossom/AppDelegate.mm
+++ b/ios/meditation_blossom/AppDelegate.mm
@@ -398,14 +398,20 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
   NSMutableDictionary *sermonData = [SermonBuilder buildFromPayload:data sourceId:sourceId];
   if (data[@"video_url"]) sermonData[@"video_url"] = data[@"video_url"];
   
-  if ([sermonData[@"topic"] containsString:@"v2"]) {
+  // sermon_events_v2 과 qt_events 모두 bible_references 배열로 말씀 데이터가 전달된다.
+  // content 필드는 FCM 4KB 제약으로 포함되지 않으며, 빈 배열([])은 말씀 없는 날을 의미한다.
+  // 서버는 snake_case 키(verse_start, verse_end)를 사용한다.
+  NSString *topic = sermonData[@"topic"] ?: @"";
+  BOOL shouldResolveBibleRefs = [topic containsString:@"v2"] || [topic containsString:@"qt_events"];
+  if (shouldResolveBibleRefs) {
     NSArray<NSDictionary *> *refs = sermonData[@"bible_references"];
     NSMutableString *builtContent = [NSMutableString string];
     for (NSDictionary *ref in refs) {
         NSString *book = [ref[@"book"] isKindOfClass:[NSString class]] ? ref[@"book"] : nil;
         NSNumber *chapterNum = [ref[@"chapter"] isKindOfClass:[NSNumber class]] ? ref[@"chapter"] : nil;
-        NSNumber *startNum = [ref[@"verseStart"] isKindOfClass:[NSNumber class]] ? ref[@"verseStart"] : nil;
-        NSNumber *endNum = [ref[@"verseEnd"] isKindOfClass:[NSNumber class]] ? ref[@"verseEnd"] : nil;
+        // 서버는 snake_case 키(verse_start, verse_end)로 전송
+        NSNumber *startNum = [ref[@"verse_start"] isKindOfClass:[NSNumber class]] ? ref[@"verse_start"] : nil;
+        NSNumber *endNum   = [ref[@"verse_end"]   isKindOfClass:[NSNumber class]] ? ref[@"verse_end"]   : nil;
 
         if (!book || !chapterNum || !startNum || !endNum) continue;
 
@@ -413,14 +419,12 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
                                                            chapter:chapterNum.intValue
                                                         verseStart:startNum.intValue
                                                           verseEnd:endNum.intValue];
-      if (text.length == 0) continue;
-      if (builtContent.length > 0) [builtContent appendString:@"\n\n"];
-      [builtContent appendString:text];
+        if (text.length == 0) continue;
+        if (builtContent.length > 0) [builtContent appendString:@"\n\n"];
+        [builtContent appendString:text];
     }
-
-    if (builtContent.length > 0) {
-      sermonData[@"content"] = builtContent;
-    }
+    // 말씀 없는 날(빈 배열)은 content를 빈 문자열로 설정
+    sermonData[@"content"] = builtContent;
   }
   
   NSError *error;

--- a/ios/meditation_blossom/AppDelegate.mm
+++ b/ios/meditation_blossom/AppDelegate.mm
@@ -400,7 +400,7 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
   
   // sermon_events_v2 과 qt_events 모두 bible_references 배열로 말씀 데이터가 전달된다.
   // content 필드는 FCM 4KB 제약으로 포함되지 않으며, 빈 배열([])은 말씀 없는 날을 의미한다.
-  // 서버는 snake_case 키(verse_start, verse_end)를 사용한다.
+  // 서버는 snake_case 키(verse_start, verse_end) 사용, 또한 verses 배열로 본문을 미리 제공할 수 있다.
   NSString *topic = sermonData[@"topic"] ?: @"";
   BOOL shouldResolveBibleRefs = [topic containsString:@"v2"] || [topic containsString:@"qt_events"];
   if (shouldResolveBibleRefs) {
@@ -409,19 +409,52 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
     for (NSDictionary *ref in refs) {
         NSString *book = [ref[@"book"] isKindOfClass:[NSString class]] ? ref[@"book"] : nil;
         NSNumber *chapterNum = [ref[@"chapter"] isKindOfClass:[NSNumber class]] ? ref[@"chapter"] : nil;
-        // 서버는 snake_case 키(verse_start, verse_end)로 전송
         NSNumber *startNum = [ref[@"verse_start"] isKindOfClass:[NSNumber class]] ? ref[@"verse_start"] : nil;
         NSNumber *endNum   = [ref[@"verse_end"]   isKindOfClass:[NSNumber class]] ? ref[@"verse_end"]   : nil;
 
         if (!book || !chapterNum || !startNum || !endNum) continue;
 
-        NSString *text = [[BibleDbHelper shared] getVersesWithBook:book
-                                                           chapter:chapterNum.intValue
-                                                        verseStart:startNum.intValue
-                                                          verseEnd:endNum.intValue];
-        if (text.length == 0) continue;
+        int from = startNum.intValue;
+        int to   = endNum.intValue;
+        NSString *rangeStr = (from == to)
+            ? [NSString stringWithFormat:@"%d:%d", chapterNum.intValue, from]
+            : [NSString stringWithFormat:@"%d:%d-%d", chapterNum.intValue, from, to];
+
+        NSMutableString *verseBody = [NSMutableString string];
+
+        // 서버가 verses 배열로 본문을 미리 제공하면 DB 조회 불필요
+        NSArray *verses = [ref[@"verses"] isKindOfClass:[NSArray class]] ? ref[@"verses"] : nil;
+        if (verses.count > 0) {
+            for (NSDictionary *verse in verses) {
+                NSString *content = [verse[@"content"] isKindOfClass:[NSString class]] ? verse[@"content"] : nil;
+                if (!content || content.length == 0) continue;
+                NSNumber *verseNum = [verse[@"verse_number"] isKindOfClass:[NSNumber class]] ? verse[@"verse_number"] : nil;
+                if (verseBody.length > 0) [verseBody appendString:@" "];
+                if (verseNum) {
+                    [verseBody appendFormat:@"%@ %@", verseNum, content];
+                } else {
+                    [verseBody appendString:content];
+                }
+            }
+        }
+
+        // embedded verses 없으면 bible.db 직접 조회
+        if (verseBody.length == 0) {
+            NSString *text = [[BibleDbHelper shared] getVersesWithBook:book
+                                                               chapter:chapterNum.intValue
+                                                            verseStart:from
+                                                              verseEnd:to];
+            if (text.length > 0) {
+                [verseBody appendString:text];
+            }
+        }
+
+        if (verseBody.length == 0) continue;
+
+        // extractContent(sermonParser.ts)가 파싱할 수 있는 포맷:
+        // "본문 : 사무엘상 17:31-37 31 어떤 사람이..."
         if (builtContent.length > 0) [builtContent appendString:@"\n\n"];
-        [builtContent appendString:text];
+        [builtContent appendFormat:@"본문 : %@ %@ %@", book, rangeStr, verseBody];
     }
     // 말씀 없는 날(빈 배열)은 content를 빈 문자열로 설정
     sermonData[@"content"] = builtContent;

--- a/ios/meditation_blossom/BibleDbHelper.swift
+++ b/ios/meditation_blossom/BibleDbHelper.swift
@@ -34,7 +34,8 @@ final class BibleDbHelper: NSObject {
             return
         }
 
-        if sqlite3_open(path, &db) != SQLITE_OK {
+        // SQLITE_OPEN_FULLMUTEX: serialized 모드 (멀티스레드 안전)
+        if sqlite3_open_v2(path, &db, SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX, nil) != SQLITE_OK {
             let message = db.flatMap { String(cString: sqlite3_errmsg($0)) } ?? "unknown"
             NSLog("❌ Failed to open DB: %@", message)
             if db != nil {

--- a/ios/meditation_blossom/BibleDbHelper.swift
+++ b/ios/meditation_blossom/BibleDbHelper.swift
@@ -49,7 +49,12 @@ final class BibleDbHelper: NSObject {
     }
 
     private func databasePath() -> String? {
-        Bundle.main.path(forResource: "bible", ofType: "db")
+        // Bundle.main 대신 Bundle(for:) 사용:
+        // App Extension 타겟(PushNotificationService)에서는 Bundle.main이
+        // Extension 자신의 번들을 가리키므로 이 방식도 동작하지만,
+        // 명시적으로 이 클래스가 컴파일된 번들에서 찾도록 지정하여
+        // 멀티 타겟 환경에서도 안전하게 동작하도록 한다.
+        Bundle(for: BibleDbHelper.self).path(forResource: "bible", ofType: "db")
     }
 
     @objc(getVersesWithBook:chapter:verseStart:verseEnd:)

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/nonimes/Documents/ManDev/meditation_blossom_frontend/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/nonimes/Documents/ManDev/meditation_blossom_frontend/node_modules

--- a/src/hooks/useQtData.ts
+++ b/src/hooks/useQtData.ts
@@ -36,17 +36,15 @@ export function useQtData(): UseQtDataReturn {
       // content가 비어 있으면 Firestore에서 재조회
       // (App Group → AsyncStorage 경유 시 bible_references가 없는 구 포맷 데이터일 수 있음)
       if (selected && !selected.content) {
-        logger.log('[QT] content 없음 → Firestore 재조회');
         try {
           const fresh = await fetchLatestQtFromServer();
           if (fresh) {
             await saveQtToAsyncStorage(fresh);
             setQt(fresh);
-            logger.log('[QT] Firestore 재조회 완료, content=' + (fresh.content ? fresh.content.slice(0, 30) + '...' : '(empty)'));
             return fresh;
           }
         } catch (fetchErr) {
-          logger.warn('[QT] Firestore 재조회 실패 (오프라인?)', fetchErr);
+          logger.warn('useQtData: Firestore fallback failed (offline?)', fetchErr);
         }
       }
 

--- a/src/hooks/useQtData.ts
+++ b/src/hooks/useQtData.ts
@@ -32,6 +32,24 @@ export function useQtData(): UseQtDataReturn {
       logger.log('AsyncStorage qt:', selected ? selected.date : 'null');
       setQt(selected);
       setError(null);
+
+      // content가 비어 있으면 Firestore에서 재조회
+      // (App Group → AsyncStorage 경유 시 bible_references가 없는 구 포맷 데이터일 수 있음)
+      if (selected && !selected.content) {
+        logger.log('[QT] content 없음 → Firestore 재조회');
+        try {
+          const fresh = await fetchLatestQtFromServer();
+          if (fresh) {
+            await saveQtToAsyncStorage(fresh);
+            setQt(fresh);
+            logger.log('[QT] Firestore 재조회 완료, content=' + (fresh.content ? fresh.content.slice(0, 30) + '...' : '(empty)'));
+            return fresh;
+          }
+        } catch (fetchErr) {
+          logger.warn('[QT] Firestore 재조회 실패 (오프라인?)', fetchErr);
+        }
+      }
+
       return selected;
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);

--- a/src/services/qtService.ts
+++ b/src/services/qtService.ts
@@ -26,7 +26,6 @@ export async function fetchLatestQtFromAsyncStorage(): Promise<QT | null> {
     raw = await AsyncStorage.getItem(FCM_QT_KEY);
     if (raw) {
       const parsed = JSON.parse(raw) as QTRaw;
-      logger.log('[QT] AsyncStorage raw: content=' + (parsed.content ? parsed.content.slice(0, 30) + '...' : '(empty)') + ', has_bible_refs=' + !!parsed.bible_references);
       const qt = fcmDataToQt(parsed);
 
       // content가 비어 있고 bible_references가 있으면 네이티브 DB 조회
@@ -36,12 +35,10 @@ export async function fetchLatestQtFromAsyncStorage(): Promise<QT | null> {
           const refsJson = typeof parsed.bible_references === 'string'
             ? parsed.bible_references
             : JSON.stringify(parsed.bible_references);
-          logger.log('[QT] content 없음 → resolveBibleReferences 호출, refs=' + refsJson.slice(0, 80));
           const resolved = await WidgetUpdateModule.resolveBibleReferences(refsJson);
-          logger.log('[QT] resolveBibleReferences 결과: ' + (resolved ? resolved.slice(0, 50) + '...' : '(empty)'));
           return { ...qt, content: resolved };
         } catch (e) {
-          logger.error('[QT] fetchLatestQtFromAsyncStorage: resolveBibleReferences failed', e);
+          logger.error('fetchLatestQtFromAsyncStorage: resolveBibleReferences failed', e);
         }
       }
 

--- a/src/services/qtService.ts
+++ b/src/services/qtService.ts
@@ -16,6 +16,7 @@ import {
   QT,
   QTRaw,
 } from '../types/QT';
+import WidgetUpdateModule from '../types/WidgetUpdateModule';
 import logger from '../utils/logger';
 
 
@@ -24,7 +25,27 @@ export async function fetchLatestQtFromAsyncStorage(): Promise<QT | null> {
   try {
     raw = await AsyncStorage.getItem(FCM_QT_KEY);
     if (raw) {
-      return fcmDataToQt(JSON.parse(raw) as QTRaw);
+      const parsed = JSON.parse(raw) as QTRaw;
+      logger.log('[QT] AsyncStorage raw: content=' + (parsed.content ? parsed.content.slice(0, 30) + '...' : '(empty)') + ', has_bible_refs=' + !!parsed.bible_references);
+      const qt = fcmDataToQt(parsed);
+
+      // content가 비어 있고 bible_references가 있으면 네이티브 DB 조회
+      // (FCM v2 포맷: content 없이 bible_references만 전달, native가 못 처리한 경우)
+      if (!qt.content && parsed.bible_references) {
+        try {
+          const refsJson = typeof parsed.bible_references === 'string'
+            ? parsed.bible_references
+            : JSON.stringify(parsed.bible_references);
+          logger.log('[QT] content 없음 → resolveBibleReferences 호출, refs=' + refsJson.slice(0, 80));
+          const resolved = await WidgetUpdateModule.resolveBibleReferences(refsJson);
+          logger.log('[QT] resolveBibleReferences 결과: ' + (resolved ? resolved.slice(0, 50) + '...' : '(empty)'));
+          return { ...qt, content: resolved };
+        } catch (e) {
+          logger.error('[QT] fetchLatestQtFromAsyncStorage: resolveBibleReferences failed', e);
+        }
+      }
+
+      return qt;
     }
   } catch (error) {
     logger.warn('Failed to load QT from AsyncStorage, clearing corrupted data');

--- a/src/types/QT.ts
+++ b/src/types/QT.ts
@@ -67,15 +67,16 @@ export const firestoreDocToQt = async (
   const data = doc.data();
   let content = data.content || '';
   const bibleRefs = data.bible_references;
-  if (Platform.OS === 'android' && bibleRefs) {
+  if (bibleRefs) {
+    // Android: BibleReferenceResolver(Kotlin) 호출
+    // iOS: WidgetUpdateModule.resolveBibleReferences(Swift/BibleDbHelper) 호출
+    // 두 플랫폼 모두 동일한 JS 경로 사용
     try {
       content = await WidgetUpdateModule.resolveBibleReferences(JSON.stringify(bibleRefs));
     } catch (e) {
       logger.error('firestoreDocToQt: bridge resolveBibleReferences failed', e);
       content = '';
     }
-  } else if (Platform.OS === 'ios' && bibleRefs) {
-    content = '';
   }
   return {
     id: doc.id,

--- a/src/types/Sermon.ts
+++ b/src/types/Sermon.ts
@@ -127,7 +127,10 @@ export const firestoreDocToSermon = async (
 
   let content = firestoreData.content || '';
   const bibleRefs = firestoreData.bible_references;
-  if (Platform.OS === 'android' && bibleRefs) {
+  if (bibleRefs) {
+    // Android: BibleReferenceResolver(Kotlin) 호출
+    // iOS: WidgetUpdateModule.resolveBibleReferences(Swift/BibleDbHelper) 호출
+    // 두 플랫폼 모두 동일한 JS 경로 사용
     try {
       const resolved = await WidgetUpdateModule.resolveBibleReferences(
         JSON.stringify(bibleRefs),
@@ -137,8 +140,6 @@ export const firestoreDocToSermon = async (
       logger.error('firestoreDocToSermon: bridge resolveBibleReferences failed', e);
       content = '';
     }
-  } else if (Platform.OS === 'ios' && bibleRefs) {
-    content = '';
   }
 
   return {


### PR DESCRIPTION
## 개요

FCM 4KB 제약으로 v2 토픽(`sermon_events_v2`, `qt_events`)에서 `content` 필드가 제외되고 `bible_references` 배열로 말씀 데이터가 전달됨에 따라 iOS bible_references 기반 본문 조회를 완성합니다. Android #77과 동일한 패턴.

## 변경 사항 요약 (9개 파일, +206 -36)

### iOS Native
- **`BibleDbHelper.swift`**: `Bundle(for:)` 변경(Extension 지원), `SQLITE_OPEN_FULLMUTEX`(멀티스레드 안전)
- **`project.pbxproj`**: BibleDbHelper.swift를 PushNotificationService 타겟 Sources에 추가
- **`AppDelegate.mm`**: qt_events 조건 추가, verse_start/verse_end key 수정, embedded verses 우선 사용, `"본문 : 책명 장:절"` 포맷 적용
- **`NotificationService.swift`**: 앱 terminated 상태에서도 bible_references → content 변환
- **`WidgetUpdateModule.swift`**: embedded verses 우선 사용, `"본문 : "` 포맷, 직렬 DispatchQueue(SQLite 멀티스레드 방지), `BibleDbHelper.shared` 사용

### JS/TypeScript
- **`QT.ts`, `Sermon.ts`**: iOS platform 제한 제거 → `WidgetUpdateModule.resolveBibleReferences` 호출
- **`qtService.ts`**: AsyncStorage에서 content 없고 bible_references 있으면 네이티브 DB 조회
- **`useQtData.ts`**: content 없으면 Firestore 재조회 (App Group 경유 구 포맷 데이터 fallback)

## 테스트 결과
- [x] 주일 말씀 탭: 앱 시작 시 말씀 본문 표시
- [x] 매일 만나 탭: 앱 시작 시 말씀 본문 및 묵상 질문 표시
- [x] 앱 terminated 상태 FCM 수신 후 재시작 시 본문 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)