### PR TITLE
[ISSUE-131] Android QT 위젯 묵상 질문 prefix 개선

### DIFF
--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetLarge.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetLarge.kt
@@ -26,6 +26,7 @@ import app.mannadev.meditation.R
 import app.mannadev.meditation.analytics.CrashlyticsHelper
 import app.mannadev.meditation.di.getWidgetDependencies
 import app.mannadev.meditation.ui.widget.qt.QtWidgetUiModel
+import app.mannadev.meditation.ui.widget.qt.prefixQuestions
 import app.mannadev.meditation.ui.widget.theme.Typography
 import timber.log.Timber
 
@@ -115,7 +116,7 @@ private fun QtWidgetLargeContent(ui: QtWidgetUiModel, clickAction: Action) {
                 )
             }
             if (ui.questions.isNotEmpty()) {
-                val bulletedQuestions = ui.questions.map { question -> "• $question" }
+                val prefixed = prefixQuestions(ui.questions)
                 item { Spacer(GlanceModifier.height(VerseLargeQtDimens.sectionGap)) }
                 item {
                     Text(
@@ -127,7 +128,7 @@ private fun QtWidgetLargeContent(ui: QtWidgetUiModel, clickAction: Action) {
                     )
                 }
                 item { Spacer(GlanceModifier.height(VerseLargeQtDimens.sectionInnerGap)) }
-                items(bulletedQuestions) { question ->
+                items(prefixed) { question ->
                     Text(
                         modifier = GlanceModifier
                             .fillMaxWidth()

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetSmall.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetSmall.kt
@@ -30,6 +30,7 @@ import app.mannadev.meditation.R
 import app.mannadev.meditation.analytics.CrashlyticsHelper
 import app.mannadev.meditation.di.getWidgetDependencies
 import app.mannadev.meditation.ui.widget.qt.QtWidgetUiModel
+import app.mannadev.meditation.ui.widget.qt.prefixQuestions
 import app.mannadev.meditation.ui.widget.theme.Typography
 import timber.log.Timber
 
@@ -121,7 +122,7 @@ private fun QtWidgetSmallContent(ui: QtWidgetUiModel, clickAction: Action) {
                     )
                 }
                 if (ui.questions.isNotEmpty()) {
-                    val bulletedQuestions = ui.questions.map { question -> "• $question" }
+                    val prefixed = prefixQuestions(ui.questions)
                     item { Spacer(GlanceModifier.height(VerseSmallQtDimens.sectionGap)) }
                     item {
                         Box(
@@ -149,7 +150,7 @@ private fun QtWidgetSmallContent(ui: QtWidgetUiModel, clickAction: Action) {
                     }
                     item { Spacer(GlanceModifier.height(VerseSmallQtDimens.sectionGap)) }
 
-                    bulletedQuestions.forEachIndexed { index, question ->
+                    prefixed.forEachIndexed { index, question ->
                         item {
                             Text(
                                 modifier = GlanceModifier
@@ -159,7 +160,7 @@ private fun QtWidgetSmallContent(ui: QtWidgetUiModel, clickAction: Action) {
                                 style = Typography.bodyMedium,
                             )
                         }
-                        if (index < bulletedQuestions.size - 1) {
+                        if (index < prefixed.size - 1) {
                             item { Spacer(GlanceModifier.height(VerseSmallQtDimens.sectionGap)) }
                         }
                     }

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/qt/QtWidgetUiModel.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/qt/QtWidgetUiModel.kt
@@ -66,3 +66,9 @@ internal fun formatDateLabel(date: String, dayOfWeek: String): String {
     val parsedDate = runCatching { DATE_INPUT_FORMAT.parse(date) }.getOrNull() ?: return day
     return "${DATE_OUTPUT_FORMAT.format(parsedDate)} · $day"
 }
+
+internal fun prefixQuestions(questions: List<String>): List<String> = when {
+    questions.isEmpty() -> emptyList()
+    questions.size == 1 -> listOf("* ${questions[0]}")
+    else -> questions.mapIndexed { index, q -> "${index + 1}. $q" }
+}

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/qt/QtWidgetUiModel.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/qt/QtWidgetUiModel.kt
@@ -69,6 +69,6 @@ internal fun formatDateLabel(date: String, dayOfWeek: String): String {
 
 internal fun prefixQuestions(questions: List<String>): List<String> = when {
     questions.isEmpty() -> emptyList()
-    questions.size == 1 -> listOf("* ${questions[0]}")
+    questions.size == 1 -> listOf("• ${questions[0]}")
     else -> questions.mapIndexed { index, q -> "${index + 1}. $q" }
 }

--- a/android/app/src/test/java/app/mannadev/meditation/ui/widget/qt/PrefixQuestionsTest.kt
+++ b/android/app/src/test/java/app/mannadev/meditation/ui/widget/qt/PrefixQuestionsTest.kt
@@ -1,0 +1,37 @@
+package app.mannadev.meditation.ui.widget.qt
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PrefixQuestionsTest {
+
+    @Test
+    fun `single question uses asterisk prefix`() {
+        val questions = listOf("하나님이 보이지 않을 때 나의 시선은 어디를 향합니까?")
+        val result = prefixQuestions(questions)
+        assertEquals(listOf("* 하나님이 보이지 않을 때 나의 시선은 어디를 향합니까?"), result)
+    }
+
+    @Test
+    fun `multiple questions use numbered prefix`() {
+        val questions = listOf(
+            "하나님이 보이지 않을 때 나의 시선은 어디를 향합니까?",
+            "❶ 나의 필요와 욕망이 채워지지 않아도 주로 인해 기뻐할 수 있습니까?",
+            "❷ 모든 것을 잃어도 하나님의 사랑과 구원으로 다시 시작할 수 있습니까?",
+        )
+        val result = prefixQuestions(questions)
+        assertEquals(
+            listOf(
+                "1. 하나님이 보이지 않을 때 나의 시선은 어디를 향합니까?",
+                "2. ❶ 나의 필요와 욕망이 채워지지 않아도 주로 인해 기뻐할 수 있습니까?",
+                "3. ❷ 모든 것을 잃어도 하나님의 사랑과 구원으로 다시 시작할 수 있습니까?",
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `empty list returns empty list`() {
+        assertEquals(emptyList<String>(), prefixQuestions(emptyList()))
+    }
+}

--- a/android/app/src/test/java/app/mannadev/meditation/ui/widget/qt/PrefixQuestionsTest.kt
+++ b/android/app/src/test/java/app/mannadev/meditation/ui/widget/qt/PrefixQuestionsTest.kt
@@ -9,7 +9,7 @@ class PrefixQuestionsTest {
     fun `single question uses asterisk prefix`() {
         val questions = listOf("하나님이 보이지 않을 때 나의 시선은 어디를 향합니까?")
         val result = prefixQuestions(questions)
-        assertEquals(listOf("* 하나님이 보이지 않을 때 나의 시선은 어디를 향합니까?"), result)
+        assertEquals(listOf("• 하나님이 보이지 않을 때 나의 시선은 어디를 향합니까?"), result)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- 묵상 질문이 1개일 때: `• question` → `* question`
- 묵상 질문이 2개 이상일 때: `• question` → `1. question`, `2. question`, ...
- `prefixQuestions` 순수 함수를 `QtWidgetUiModel.kt`에 추출하여 단위 테스트 커버

## Test Plan

- [ ] Android 기기/에뮬레이터에서 QT 위젯(Large/Small) 확인
  - 질문 1개: `* 질문 텍스트` 형태로 표시되는지 확인
  - 질문 복수 개: `1. 질문`, `2. 질문` 형태로 표시되는지 확인
- [ ] `❶`, `❷` 등 기존 텍스트 prefix가 그대로 유지되는지 확인

Closes #131