### PR TITLE
[ISSUE-59] 주일말씀 위젯 유튜브 이동 기능 추가

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2729,7 +2729,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SwiftUIIntrospect (~> 1.0)
     - Yoga
-  - react-native-safe-area-context (5.8.0):
+  - react-native-safe-area-context (5.6.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2742,8 +2742,8 @@ PODS:
     - React-featureflags
     - React-graphics
     - React-ImageManager
-    - react-native-safe-area-context/common (= 5.8.0)
-    - react-native-safe-area-context/fabric (= 5.8.0)
+    - react-native-safe-area-context/common (= 5.6.0)
+    - react-native-safe-area-context/fabric (= 5.6.0)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -2752,7 +2752,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-safe-area-context/common (5.8.0):
+  - react-native-safe-area-context/common (5.6.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2773,7 +2773,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-safe-area-context/fabric (5.8.0):
+  - react-native-safe-area-context/fabric (5.6.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3678,7 +3678,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 9089a8ef738526aa31bb993debfaff214c2bef5d
   React-microtasksnativemodule: d4fd1d752f04965cd989beb8d28e896fa7f58605
   react-native-pager-view: e3245afdb4b97b1315089d8c0873eacdaefe5e17
-  react-native-safe-area-context: fe9a46a1191affbc09cca7ea4fa3ff41caa392f0
+  react-native-safe-area-context: 0bbc90d6f3f07a97c20bde638c19f61d45210e22
   React-NativeModulesApple: ce75ed8f1188483be3620bf9dbb3b1286dd39bab
   React-perflogger: 26d07766b033f84559bd520e949453dba8bf1cd8
   React-performancetimeline: 24eb0a6a341a1b0d48bc75a961ee480db0bad47e

--- a/ios/meditation_blossom.xcodeproj/project.pbxproj
+++ b/ios/meditation_blossom.xcodeproj/project.pbxproj
@@ -35,7 +35,6 @@
 		35CF0001AAAA0001AAAAAAAA /* RCTView+ColorFix.m in Sources */ = {isa = PBXBuildFile; fileRef = 35CF0000AAAA0001AAAAAAAA /* RCTView+ColorFix.m */; };
 		35D57CC72E4E12CF006A8872 /* MyEventModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 35D57CC62E4E12C1006A8872 /* MyEventModule.m */; };
 		35DF7D9B2F87741F004FEDA3 /* BibleDbHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DF7D9A2F87741F004FEDA3 /* BibleDbHelper.swift */; };
-		92C5C884FCF54E7ABBCD3904 /* BibleDbHelper.swift in Sources (PushNotificationService) */ = {isa = PBXBuildFile; fileRef = 35DF7D9A2F87741F004FEDA3; };
 		36D0ABAEB660494094DD9C97 /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = F7AF6C1D72CD4A66B58C33B8 /* Pretendard-Bold.otf */; };
 		3C0090A2347247CC84AEF51C /* Pretendard-Thin.otf in Resources */ = {isa = PBXBuildFile; fileRef = FA817E704269452E9C720D87 /* Pretendard-Thin.otf */; };
 		4BF67687D54E4D26AF6361BE /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9C169B17C3504C6E8ED9A33A /* Pretendard-SemiBold.otf */; };
@@ -44,6 +43,7 @@
 		5FFA7AF4CB71498989F6EAC3 /* Pretendard-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = 24B4574C15E64071AE2213F2 /* Pretendard-Light.otf */; };
 		648990BED925AB88A487D541 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
+		92C5C884FCF54E7ABBCD3904 /* BibleDbHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DF7D9A2F87741F004FEDA3 /* BibleDbHelper.swift */; };
 		B31C3428F30D34E28BBC910F /* Pods_meditation_blossom_meditation_blossomTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E2F272DB449267E51D19031 /* Pods_meditation_blossom_meditation_blossomTests.framework */; };
 		BF8AB1B43579418E9CD3C825 /* Pretendard-Black.otf in Resources */ = {isa = PBXBuildFile; fileRef = CA374A4D4D014BAEA21D5B01 /* Pretendard-Black.otf */; };
 		E1BCE842198A45EC0E2E6A5A /* Pods_meditation_blossom.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5999A83A0184DE1717910ED3 /* Pods_meditation_blossom.framework */; };
@@ -776,7 +776,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-
 				92C5C884FCF54E7ABBCD3904 /* BibleDbHelper.swift in Sources */,
 				35A99CA72E5F502B0087CB5B /* Sermon.swift in Sources */,
 			);

--- a/ios/meditation_blossom/AppDelegate.mm
+++ b/ios/meditation_blossom/AppDelegate.mm
@@ -4,6 +4,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTRootView.h>
 #import <React/RCTLog.h>
+#import <React/RCTLinkingManager.h>
 #import <FirebaseCore/FirebaseCore.h>
 #import <FirebaseMessaging/FirebaseMessaging.h>
 #import <FirebaseInAppMessaging/FirebaseInAppMessaging.h>
@@ -114,6 +115,24 @@
 #endif
   
   return result;
+}
+
+#pragma mark - Deep Link (URL Scheme)
+
+// 위젯/외부에서 meditationblossom:// 딥링크로 앱을 열 때, URL을 React Native(Linking)로 전달.
+// 이 전달이 없으면 App.tsx의 linking(getStateFromPath)이 동작하지 않아 마지막 화면만 복귀됨.
+- (BOOL)application:(UIApplication *)application
+            openURL:(NSURL *)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options {
+  // WidgetKit 제약: 위젯은 외부 URL(유튜브 등)을 직접 못 열고 항상 호스트 앱을 먼저 띄운다.
+  // 따라서 위젯이 https/http URL로 앱을 열면, 앱이 그 URL을 받아 직접 외부 브라우저로 넘긴다.
+  if ([url.scheme isEqualToString:@"http"] || [url.scheme isEqualToString:@"https"]) {
+    [application openURL:url options:@{} completionHandler:nil];
+    return YES;
+  }
+
+  // meditationblossom:// 딥링크는 React Native(Linking)로 전달.
+  return [RCTLinkingManager application:application openURL:url options:options];
 }
 
 #pragma mark - React Native Notification Handlers


### PR DESCRIPTION
## 개요

주일말씀 위젯을 탭하면 설정 토글에 따라 **유튜브로 이동**하거나 **앱의 "주일 말씀" 탭으로 이동**하도록 구현합니다. (이슈 #59, #60)

토글 상태는 App Group `UserDefaults`에 저장되어 위젯 Extension과 공유되며, 동작은 **안드로이드와 동일하게 통일**했습니다.

## 변경 사항

- **AppDelegate**: `application:openURL:options:` 핸들러 추가
  - 위젯이 넘긴 URL을 받는 입구가 없어 그동안 위젯 탭이 무시되던 문제 해결
  - `http(s)` URL(유튜브) → 앱이 받아 외부 브라우저로 직접 전달 (WidgetKit 제약상 위젯은 외부 URL을 직접 못 열고 호스트 앱을 먼저 띄움)
  - `meditationblossom://` 딥링크(토글 OFF) → `RCTLinkingManager`로 RN Linking에 전달해 "주일 말씀" 탭 이동

## 동작 (안드로이드와 통일)

| 항목 | 동작 |
|------|------|
| 토글 ON + 설교 영상 있음 | 해당 설교 유튜브 영상으로 이동 |
| 토글 ON + 영상 없음 | 만나 채널(`@만나`)로 이동 |
| 토글 OFF (기본값) | 앱 "주일 말씀" 탭으로 이동 |

## 검증

- 토글 ON → 위젯 탭 → 유튜브(Safari/유튜브 앱) 이동 ✅
- 토글 OFF → 위젯 탭 → "주일 말씀" 탭 이동 ✅
- iOS 시뮬레이터(iOS 26.3)에서 확인

Closes #59
Closes #60