### PR TITLE
[ISSUE-138] 유튜브 버튼 터치 인식 개선

### DIFF
--- a/src/screens/DailyMannaScreen.tsx
+++ b/src/screens/DailyMannaScreen.tsx
@@ -136,21 +136,21 @@ const DailyMannaScreen = () => {
 
   return (
     <SafeAreaView style={styles.container} edges={['bottom']}>
-      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false} onScroll={handleScroll} scrollEventThrottle={400}>
-        <View style={styles.seriesCard}>
-          <View style={styles.seriesCardText}>
-            {qt?.series_title ? (
-              <Text style={styles.seriesTitleText}>{qt.series_title}</Text>
-            ) : null}
-            <Text style={styles.dateText}>{qt?.date}</Text>
-          </View>
-          <TouchableOpacity
-            onPress={openYoutube}
-            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-          >
-            <SvgIcon name="YoutubeButton" size={60} />
-          </TouchableOpacity>
+      <View style={styles.seriesCard}>
+        <View style={styles.seriesCardText}>
+          {qt?.series_title ? (
+            <Text style={styles.seriesTitleText}>{qt.series_title}</Text>
+          ) : null}
+          <Text style={styles.dateText}>{qt?.date}</Text>
         </View>
+        <TouchableOpacity
+          onPress={openYoutube}
+          hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+        >
+          <SvgIcon name="YoutubeButton" size={60} />
+        </TouchableOpacity>
+      </View>
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false} onScroll={handleScroll} scrollEventThrottle={400}>
         <View style={styles.smallDivider} />
         <Text style={styles.titleText} numberOfLines={0}>
           {processTitleText(qt?.title)}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -115,21 +115,21 @@ const HomeScreen = () => {
   logger.log('[Home] rendering, sermon=' + (sermon?.date ?? 'null') + ', isLoading=' + isLoading + ', showSpinner=' + showSpinner);
   return (
     <SafeAreaView style={styles.container} edges={['bottom']}>
-      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false} onScroll={handleScroll} scrollEventThrottle={400}>
-        <View style={styles.seriesCard}>
-          <View style={styles.seriesCardText}>
-            {sermon?.category ? (
-              <Text style={styles.cardTitleText}>{sermon.category}</Text>
-            ) : null}
-            <Text style={styles.seriesDateText}>{sermon?.date}</Text>
-          </View>
-          <TouchableOpacity
-            onPress={openYoutube}
-            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-          >
-            <SvgIcon name="YoutubeButton" size={60} />
-          </TouchableOpacity>
+      <View style={styles.seriesCard}>
+        <View style={styles.seriesCardText}>
+          {sermon?.category ? (
+            <Text style={styles.cardTitleText}>{sermon.category}</Text>
+          ) : null}
+          <Text style={styles.seriesDateText}>{sermon?.date}</Text>
         </View>
+        <TouchableOpacity
+          onPress={openYoutube}
+          hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+        >
+          <SvgIcon name="YoutubeButton" size={60} />
+        </TouchableOpacity>
+      </View>
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false} onScroll={handleScroll} scrollEventThrottle={400}>
         <View style={styles.smallDivider} />
         <Text style={styles.titleText} numberOfLines={0}>
           {processTitleText(sermon?.title)}


### PR DESCRIPTION
Closes #138

## 원인
유튜브 버튼이 포함된 `seriesCard`가 `ScrollView` 내부에 있어, 손가락이 아주 조금만 움직이면 ScrollView가 스크롤 제스처로 터치를 가로채 `onPress`가 발동하지 않는 전형적인 React Native 문제.

## 변경 내용
- `seriesCard`를 `ScrollView` 바깥 고정 헤더로 이동 (두 화면 동일하게 적용)
  - `ScrollView` 안에는 말씀 본문(제목·내용·묵상 질문)만 남김
- `hitSlop` 8 → 12pt 확대해 터치 여유 면적 추가 확보

```
Before:
  SafeAreaView
  └── ScrollView
        ├── seriesCard (유튜브 버튼) ← 스크롤 제스처와 충돌
        └── 말씀 본문...

After:
  SafeAreaView
  ├── seriesCard (유튜브 버튼) ← ScrollView 바깥, 터치 확실하게 인식
  └── ScrollView
        └── 말씀 본문...
```

## 영향 파일
- `src/screens/HomeScreen.tsx`
- `src/screens/DailyMannaScreen.tsx`

## 테스트 계획
- [ ] 주일 말씀 탭에서 유튜브 버튼 10회 연속 탭 → 매번 유튜브 이동 확인
- [ ] 매일 만나 탭에서 동일 확인
- [ ] 버튼을 누르면서 손가락을 조금 움직여도 onPress 발동 확인
- [ ] 말씀 본문 영역 스크롤 정상 작동 확인
- [ ] 시리즈 카드(제목·날짜 텍스트) 레이아웃 시각적으로 이상 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)