### PR TITLE
[ISSUE-138] 유튜브 버튼 터치 인식 개선

### DIFF
--- a/src/navigation/JsPager.tsx
+++ b/src/navigation/JsPager.tsx
@@ -69,7 +69,9 @@ type PagerAdapterProps<T extends Route> = {
 
 // ─── PanResponderAdapter (JS 페이저) ─────────────────────────────────────────
 
-const DEAD_ZONE = 12;
+// 12px에서 40px로 높임: 작은 손가락 떨림이 스와이프로 인식되어
+// 버튼 onPress를 탈취하는 문제 방지 (의도적인 스와이프는 40px로도 충분히 인식됨)
+const DEAD_ZONE = 40;
 
 const DefaultTransitionSpec = {
   timing: Animated.spring,
@@ -254,7 +256,9 @@ export function JsPager<T extends Route>({
 
   const panResponder = PanResponder.create({
     onMoveShouldSetPanResponder: canMoveScreen,
-    onMoveShouldSetPanResponderCapture: canMoveScreen,
+    // Capture 단계 제거: 자식 버튼이 onStartShouldSetResponder로 먼저 터치를 확보한 경우,
+    // Capture 단계에서 스와이프 제스처가 가로채지 않도록 한다.
+    // 스와이프는 버블 단계(onMoveShouldSetPanResponder)와 확장된 DEAD_ZONE으로 처리.
     onPanResponderGrant: startGesture,
     onPanResponderMove: respondToGesture,
     onPanResponderTerminate: finishGesture,

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -83,7 +83,6 @@ const MainTabNavigator = () => {
       <Tab.Navigator
         tabBar={(props) => <CustomTabBar {...props} />}
         initialLayout={{ width: SCREEN_WIDTH }}
-        swipeEnabled={false}
       >
         <Tab.Screen name="주일 말씀" component={HomeScreen} />
         <Tab.Screen name="매일 만나" component={DailyMannaScreen} />

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -83,6 +83,7 @@ const MainTabNavigator = () => {
       <Tab.Navigator
         tabBar={(props) => <CustomTabBar {...props} />}
         initialLayout={{ width: SCREEN_WIDTH }}
+        swipeEnabled={false}
       >
         <Tab.Screen name="주일 말씀" component={HomeScreen} />
         <Tab.Screen name="매일 만나" component={DailyMannaScreen} />

--- a/src/screens/DailyMannaScreen.tsx
+++ b/src/screens/DailyMannaScreen.tsx
@@ -4,6 +4,7 @@ import {
   Linking,
   NativeScrollEvent,
   NativeSyntheticEvent,
+  Pressable,
   ScrollView,
   StyleSheet,
   Text,
@@ -136,21 +137,22 @@ const DailyMannaScreen = () => {
 
   return (
     <SafeAreaView style={styles.container} edges={['bottom']}>
-      <View style={styles.seriesCard}>
-        <View style={styles.seriesCardText}>
-          {qt?.series_title ? (
-            <Text style={styles.seriesTitleText}>{qt.series_title}</Text>
-          ) : null}
-          <Text style={styles.dateText}>{qt?.date}</Text>
-        </View>
-        <TouchableOpacity
-          onPress={openYoutube}
-          hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
-        >
-          <SvgIcon name="YoutubeButton" size={60} />
-        </TouchableOpacity>
-      </View>
       <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false} onScroll={handleScroll} scrollEventThrottle={400}>
+        <View style={styles.seriesCard}>
+          <View style={styles.seriesCardText}>
+            {qt?.series_title ? (
+              <Text style={styles.seriesTitleText}>{qt.series_title}</Text>
+            ) : null}
+            <Text style={styles.dateText}>{qt?.date}</Text>
+          </View>
+          <Pressable
+            onPress={openYoutube}
+            hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+            cancelable={false}
+          >
+            <SvgIcon name="YoutubeButton" size={60} />
+          </Pressable>
+        </View>
         <View style={styles.smallDivider} />
         <Text style={styles.titleText} numberOfLines={0}>
           {processTitleText(qt?.title)}

--- a/src/screens/DailyMannaScreen.tsx
+++ b/src/screens/DailyMannaScreen.tsx
@@ -136,21 +136,21 @@ const DailyMannaScreen = () => {
 
   return (
     <SafeAreaView style={styles.container} edges={['bottom']}>
-      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false} onScroll={handleScroll} scrollEventThrottle={400}>
-        <View style={styles.seriesCard}>
-          <View style={styles.seriesCardText}>
-            {qt?.series_title ? (
-              <Text style={styles.seriesTitleText}>{qt.series_title}</Text>
-            ) : null}
-            <Text style={styles.dateText}>{qt?.date}</Text>
-          </View>
-          <TouchableOpacity
-            onPress={openYoutube}
-            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-          >
-            <SvgIcon name="YoutubeButton" size={60} />
-          </TouchableOpacity>
+      <View style={styles.seriesCard}>
+        <View style={styles.seriesCardText}>
+          {qt?.series_title ? (
+            <Text style={styles.seriesTitleText}>{qt.series_title}</Text>
+          ) : null}
+          <Text style={styles.dateText}>{qt?.date}</Text>
         </View>
+        <TouchableOpacity
+          onPress={openYoutube}
+          hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+        >
+          <SvgIcon name="YoutubeButton" size={60} />
+        </TouchableOpacity>
+      </View>
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false} onScroll={handleScroll} scrollEventThrottle={400}>
         <View style={styles.smallDivider} />
         <Text style={styles.titleText} numberOfLines={0}>
           {processTitleText(qt?.title)}

--- a/src/screens/DailyMannaScreen.tsx
+++ b/src/screens/DailyMannaScreen.tsx
@@ -138,21 +138,19 @@ const DailyMannaScreen = () => {
   return (
     <SafeAreaView style={styles.container} edges={['bottom']}>
       <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false} onScroll={handleScroll} scrollEventThrottle={400}>
-        <View style={styles.seriesCard}>
+        <Pressable
+          style={styles.seriesCard}
+          onPress={openYoutube}
+          cancelable={false}
+        >
           <View style={styles.seriesCardText}>
             {qt?.series_title ? (
               <Text style={styles.seriesTitleText}>{qt.series_title}</Text>
             ) : null}
             <Text style={styles.dateText}>{qt?.date}</Text>
           </View>
-          <Pressable
-            onPress={openYoutube}
-            hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
-            cancelable={false}
-          >
-            <SvgIcon name="YoutubeButton" size={60} />
-          </Pressable>
-        </View>
+          <SvgIcon name="YoutubeButton" size={60} />
+        </Pressable>
         <View style={styles.smallDivider} />
         <Text style={styles.titleText} numberOfLines={0}>
           {processTitleText(qt?.title)}

--- a/src/screens/DailyMannaScreen.tsx
+++ b/src/screens/DailyMannaScreen.tsx
@@ -138,19 +138,21 @@ const DailyMannaScreen = () => {
   return (
     <SafeAreaView style={styles.container} edges={['bottom']}>
       <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false} onScroll={handleScroll} scrollEventThrottle={400}>
-        <Pressable
-          style={styles.seriesCard}
-          onPress={openYoutube}
-          cancelable={false}
-        >
+        <View style={styles.seriesCard}>
           <View style={styles.seriesCardText}>
             {qt?.series_title ? (
               <Text style={styles.seriesTitleText}>{qt.series_title}</Text>
             ) : null}
             <Text style={styles.dateText}>{qt?.date}</Text>
           </View>
-          <SvgIcon name="YoutubeButton" size={60} pointerEvents="none" />
-        </Pressable>
+          <Pressable
+            onPress={openYoutube}
+            hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+            cancelable={false}
+          >
+            <SvgIcon name="YoutubeButton" size={60} pointerEvents="none" />
+          </Pressable>
+        </View>
         <View style={styles.smallDivider} />
         <Text style={styles.titleText} numberOfLines={0}>
           {processTitleText(qt?.title)}

--- a/src/screens/DailyMannaScreen.tsx
+++ b/src/screens/DailyMannaScreen.tsx
@@ -149,7 +149,7 @@ const DailyMannaScreen = () => {
             ) : null}
             <Text style={styles.dateText}>{qt?.date}</Text>
           </View>
-          <SvgIcon name="YoutubeButton" size={60} />
+          <SvgIcon name="YoutubeButton" size={60} pointerEvents="none" />
         </Pressable>
         <View style={styles.smallDivider} />
         <Text style={styles.titleText} numberOfLines={0}>

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -5,6 +5,7 @@ import {
   NativeScrollEvent,
   NativeSyntheticEvent,
   Platform,
+  Pressable,
   ScrollView,
   StyleSheet,
   Text,
@@ -115,21 +116,22 @@ const HomeScreen = () => {
   logger.log('[Home] rendering, sermon=' + (sermon?.date ?? 'null') + ', isLoading=' + isLoading + ', showSpinner=' + showSpinner);
   return (
     <SafeAreaView style={styles.container} edges={['bottom']}>
-      <View style={styles.seriesCard}>
-        <View style={styles.seriesCardText}>
-          {sermon?.category ? (
-            <Text style={styles.cardTitleText}>{sermon.category}</Text>
-          ) : null}
-          <Text style={styles.seriesDateText}>{sermon?.date}</Text>
-        </View>
-        <TouchableOpacity
-          onPress={openYoutube}
-          hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
-        >
-          <SvgIcon name="YoutubeButton" size={60} />
-        </TouchableOpacity>
-      </View>
       <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false} onScroll={handleScroll} scrollEventThrottle={400}>
+        <View style={styles.seriesCard}>
+          <View style={styles.seriesCardText}>
+            {sermon?.category ? (
+              <Text style={styles.cardTitleText}>{sermon.category}</Text>
+            ) : null}
+            <Text style={styles.seriesDateText}>{sermon?.date}</Text>
+          </View>
+          <Pressable
+            onPress={openYoutube}
+            hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+            cancelable={false}
+          >
+            <SvgIcon name="YoutubeButton" size={60} />
+          </Pressable>
+        </View>
         <View style={styles.smallDivider} />
         <Text style={styles.titleText} numberOfLines={0}>
           {processTitleText(sermon?.title)}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -117,21 +117,19 @@ const HomeScreen = () => {
   return (
     <SafeAreaView style={styles.container} edges={['bottom']}>
       <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false} onScroll={handleScroll} scrollEventThrottle={400}>
-        <View style={styles.seriesCard}>
+        <Pressable
+          style={styles.seriesCard}
+          onPress={openYoutube}
+          cancelable={false}
+        >
           <View style={styles.seriesCardText}>
             {sermon?.category ? (
               <Text style={styles.cardTitleText}>{sermon.category}</Text>
             ) : null}
             <Text style={styles.seriesDateText}>{sermon?.date}</Text>
           </View>
-          <Pressable
-            onPress={openYoutube}
-            hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
-            cancelable={false}
-          >
-            <SvgIcon name="YoutubeButton" size={60} />
-          </Pressable>
-        </View>
+          <SvgIcon name="YoutubeButton" size={60} />
+        </Pressable>
         <View style={styles.smallDivider} />
         <Text style={styles.titleText} numberOfLines={0}>
           {processTitleText(sermon?.title)}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -117,19 +117,21 @@ const HomeScreen = () => {
   return (
     <SafeAreaView style={styles.container} edges={['bottom']}>
       <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false} onScroll={handleScroll} scrollEventThrottle={400}>
-        <Pressable
-          style={styles.seriesCard}
-          onPress={openYoutube}
-          cancelable={false}
-        >
+        <View style={styles.seriesCard}>
           <View style={styles.seriesCardText}>
             {sermon?.category ? (
               <Text style={styles.cardTitleText}>{sermon.category}</Text>
             ) : null}
             <Text style={styles.seriesDateText}>{sermon?.date}</Text>
           </View>
-          <SvgIcon name="YoutubeButton" size={60} pointerEvents="none" />
-        </Pressable>
+          <Pressable
+            onPress={openYoutube}
+            hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+            cancelable={false}
+          >
+            <SvgIcon name="YoutubeButton" size={60} pointerEvents="none" />
+          </Pressable>
+        </View>
         <View style={styles.smallDivider} />
         <Text style={styles.titleText} numberOfLines={0}>
           {processTitleText(sermon?.title)}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -128,7 +128,7 @@ const HomeScreen = () => {
             ) : null}
             <Text style={styles.seriesDateText}>{sermon?.date}</Text>
           </View>
-          <SvgIcon name="YoutubeButton" size={60} />
+          <SvgIcon name="YoutubeButton" size={60} pointerEvents="none" />
         </Pressable>
         <View style={styles.smallDivider} />
         <Text style={styles.titleText} numberOfLines={0}>

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -115,21 +115,21 @@ const HomeScreen = () => {
   logger.log('[Home] rendering, sermon=' + (sermon?.date ?? 'null') + ', isLoading=' + isLoading + ', showSpinner=' + showSpinner);
   return (
     <SafeAreaView style={styles.container} edges={['bottom']}>
-      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false} onScroll={handleScroll} scrollEventThrottle={400}>
-        <View style={styles.seriesCard}>
-          <View style={styles.seriesCardText}>
-            {sermon?.category ? (
-              <Text style={styles.cardTitleText}>{sermon.category}</Text>
-            ) : null}
-            <Text style={styles.seriesDateText}>{sermon?.date}</Text>
-          </View>
-          <TouchableOpacity
-            onPress={openYoutube}
-            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-          >
-            <SvgIcon name="YoutubeButton" size={60} />
-          </TouchableOpacity>
+      <View style={styles.seriesCard}>
+        <View style={styles.seriesCardText}>
+          {sermon?.category ? (
+            <Text style={styles.cardTitleText}>{sermon.category}</Text>
+          ) : null}
+          <Text style={styles.seriesDateText}>{sermon?.date}</Text>
         </View>
+        <TouchableOpacity
+          onPress={openYoutube}
+          hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+        >
+          <SvgIcon name="YoutubeButton" size={60} />
+        </TouchableOpacity>
+      </View>
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false} onScroll={handleScroll} scrollEventThrottle={400}>
         <View style={styles.smallDivider} />
         <Text style={styles.titleText} numberOfLines={0}>
           {processTitleText(sermon?.title)}


### PR DESCRIPTION
Closes #138

## 근본 원인 (최종)

`TouchableOpacity`는 내부적으로 `onResponderTerminationRequest: () => true`를 반환해, PanResponder(탭 스와이프)나 ScrollView가 "터치 양보해달라"고 요청하면 무조건 수락함. 손가락이 조금만 움직여도 버튼이 터치를 잃어 `onPress`가 발동하지 않음.

DEAD_ZONE 확대, Capture 제거, ScrollView 밖 이동, `swipeEnabled={false}` 모두 근본 원인이 아니었음.

## 수정 내용

### `src/screens/HomeScreen.tsx` / `DailyMannaScreen.tsx`
- 유튜브 버튼 `TouchableOpacity` → **`Pressable(cancelable={false})`** 교체
  - `cancelable={false}` → `onResponderTerminationRequest: () => false` → 터치를 확보한 이후 어떤 제스처도 빼앗지 못함
- `seriesCard` ScrollView 안으로 복귀 (원래 위치)
- `hitSlop` 8 → 12pt 확대 유지

### `src/navigation/MainTabNavigator.tsx`
- `swipeEnabled={false}` 제거 → 탭 스와이프 복원

### `src/navigation/JsPager.tsx` (유지)
- `onMoveShouldSetPanResponderCapture` 제거
- `DEAD_ZONE` 12 → 40px (부수 개선)

## 테스트 계획
- [ ] 유튜브 버튼 10회 연속 탭 → 매번 유튜브 이동 확인 (주일 말씀 / 매일 만나)
- [ ] 버튼을 누르면서 손가락을 움직여도 onPress 발동 확인
- [ ] 탭 간 스와이프 전환 정상 확인
- [ ] 말씀 본문 영역 스크롤 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)