### PR TITLE
[HOTFIX] 주일말씀·QT 유튜브 바로가기 video_url 누락 시 서버 보충

### DIFF
--- a/__tests__/reconcileFreshDoc.test.ts
+++ b/__tests__/reconcileFreshDoc.test.ts
@@ -1,0 +1,85 @@
+import { reconcileFreshDoc } from '../src/utils/reconcileFreshDoc';
+
+type Doc = {
+  date: string;
+  content: string;
+  video_url?: string;
+  updated_at: { seconds: number; nanoseconds: number };
+};
+
+// date → updated_at 순으로 비교하는 테스트용 compare (compareSermon/compareQt와 동일 규칙)
+function compare(a: Doc | null, b: Doc | null): number {
+  if (a === null && b === null) return 0;
+  if (a === null) return -1;
+  if (b === null) return 1;
+  if (a.date > b.date) return 1;
+  if (a.date < b.date) return -1;
+  const at = a.updated_at.seconds;
+  const bt = b.updated_at.seconds;
+  return at > bt ? 1 : at < bt ? -1 : 0;
+}
+
+const make = (over: Partial<Doc>): Doc => ({
+  date: '2026-06-13',
+  content: '본문 내용',
+  updated_at: { seconds: 1000, nanoseconds: 0 },
+  ...over,
+});
+
+describe('reconcileFreshDoc', () => {
+  it('current가 null이면 fresh를 채택', () => {
+    const fresh = make({});
+    expect(reconcileFreshDoc(fresh, null, compare)).toBe(fresh);
+  });
+
+  it('fresh가 더 최신(날짜)이면 통째 교체', () => {
+    const current = make({ date: '2026-06-06' });
+    const fresh = make({ date: '2026-06-13' });
+    expect(reconcileFreshDoc(fresh, current, compare)).toBe(fresh);
+  });
+
+  it('fresh가 더 오래되면(날짜) null', () => {
+    const current = make({ date: '2026-06-13' });
+    const fresh = make({ date: '2026-06-06' });
+    expect(reconcileFreshDoc(fresh, current, compare)).toBeNull();
+  });
+
+  // 핵심 버그 케이스: 같은 날짜인데 로컬에 video_url이 없고 서버에 있을 때 보충
+  it('같은 날짜 + 로컬 video_url 없음 + 서버 있음 → video_url 보충', () => {
+    const current = make({ video_url: undefined });
+    const fresh = make({ video_url: 'https://youtu.be/abc' });
+    const result = reconcileFreshDoc(fresh, current, compare);
+    expect(result).not.toBeNull();
+    expect(result!.video_url).toBe('https://youtu.be/abc');
+  });
+
+  it('같은 날짜 + 로컬 content 없음 + 서버 있음 → content 보충', () => {
+    const current = make({ content: '' });
+    const fresh = make({ content: '본문 내용' });
+    const result = reconcileFreshDoc(fresh, current, compare);
+    expect(result).not.toBeNull();
+    expect(result!.content).toBe('본문 내용');
+  });
+
+  it('같은 날짜 + 로컬에 이미 video_url 있으면 서버 값으로 덮지 않음(머지, 기존 보존)', () => {
+    const current = make({ video_url: 'https://youtu.be/local', content: '' });
+    const fresh = make({ video_url: 'https://youtu.be/server', content: '본문 내용' });
+    const result = reconcileFreshDoc(fresh, current, compare);
+    expect(result).not.toBeNull();
+    expect(result!.video_url).toBe('https://youtu.be/local'); // 기존 값 유지
+    expect(result!.content).toBe('본문 내용'); // 빈 칸만 보충
+  });
+
+  // 영상이 원래 없는 항목: 서버에도 없으면 갱신하지 않음 → 불필요한 업데이트/루프 방지
+  it('같은 날짜 + 양쪽 다 video_url 없음 → null (불필요한 갱신 없음)', () => {
+    const current = make({ video_url: undefined });
+    const fresh = make({ video_url: undefined });
+    expect(reconcileFreshDoc(fresh, current, compare)).toBeNull();
+  });
+
+  it('같은 날짜 + 로컬에 content/video_url 모두 채워져 있으면 null', () => {
+    const current = make({ content: '본문 내용', video_url: 'https://youtu.be/x' });
+    const fresh = make({ content: '다른 본문', video_url: 'https://youtu.be/y' });
+    expect(reconcileFreshDoc(fresh, current, compare)).toBeNull();
+  });
+});

--- a/__tests__/useSermonData.test.ts
+++ b/__tests__/useSermonData.test.ts
@@ -157,6 +157,54 @@ describe('useSermonData', () => {
     });
   });
 
+  describe('loadLocalData video_url 보충 (forced fetch)', () => {
+    const localNoVideo = {
+      id: 's1',
+      title: '설교',
+      content: '본문 내용',
+      date: '2026-06-13',
+      created_at: { seconds: 0, nanoseconds: 0 },
+      updated_at: { seconds: 1000, nanoseconds: 0 },
+    };
+
+    it('로컬에 video_url이 없으면 서버에서 보충해 채운다', async () => {
+      const serverWithVideo = { ...localNoVideo, video_url: 'https://youtu.be/abc' };
+      mockFetchFromAsyncStorage.mockResolvedValue(localNoVideo);
+      mockFetchFromServer.mockResolvedValue(serverWithVideo);
+      mockSaveSermonToAsyncStorage.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useSermonData());
+      await act(async () => { await result.current.loadLocalData(); });
+
+      expect(mockFetchFromServer).toHaveBeenCalledTimes(1);
+      expect(result.current.sermon?.video_url).toBe('https://youtu.be/abc');
+      expect(mockSaveSermonToAsyncStorage).toHaveBeenCalled();
+    });
+
+    it('video_url이 이미 있으면 서버 보충 조회를 하지 않는다', async () => {
+      const localWithVideo = { ...localNoVideo, video_url: 'https://youtu.be/zzz' };
+      mockFetchFromAsyncStorage.mockResolvedValue(localWithVideo);
+
+      const { result } = renderHook(() => useSermonData());
+      await act(async () => { await result.current.loadLocalData(); });
+
+      expect(mockFetchFromServer).not.toHaveBeenCalled();
+      expect(result.current.sermon).toEqual(localWithVideo);
+    });
+
+    it('보충 조회는 세션당 1회만 시도한다 (반복 호출해도 추가 조회 없음)', async () => {
+      mockFetchFromAsyncStorage.mockResolvedValue(localNoVideo);
+      mockFetchFromServer.mockResolvedValue(null); // 서버에도 없음 → 못 채움
+
+      const { result } = renderHook(() => useSermonData());
+      await act(async () => { await result.current.loadLocalData(); });
+      await act(async () => { await result.current.loadLocalData(); });
+      await act(async () => { await result.current.loadLocalData(); });
+
+      expect(mockFetchFromServer).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('subscribeToLatestSermon (onSnapshot)', () => {
     const olderSermon = {
       id: 'older-1',

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,4 +1,6 @@
-jest.mock('@react-native-firebase/crashlytics', () => () => ({
+// logger.ts가 모듈러 API(getCrashlytics/log/recordError named export)를 사용하므로 그에 맞춰 mock
+jest.mock('@react-native-firebase/crashlytics', () => ({
+  getCrashlytics: jest.fn(() => ({})),
   log: jest.fn(),
   recordError: jest.fn(),
 }));

--- a/src/hooks/useQtData.ts
+++ b/src/hooks/useQtData.ts
@@ -8,6 +8,7 @@ import {
 } from '../services/qtService';
 import { logAnalytics } from '../utils/analytics';
 import logger from '../utils/logger';
+import { reconcileFreshDoc } from '../utils/reconcileFreshDoc';
 
 export interface UseQtDataReturn {
   qt: QT | null;
@@ -25,6 +26,8 @@ export function useQtData(): UseQtDataReturn {
   const [error, setError] = useState<string | null>(null);
   const qtRef = useRef<QT | null>(null);
   qtRef.current = qt;
+  // video_url/content 보충용 서버 강제 조회를 세션당 1회로 제한 (영상이 원래 없는 항목에서 반복 조회 방지)
+  const triedServerFill = useRef(false);
 
   const loadLocalData = useCallback(async (): Promise<QT | null> => {
     try {
@@ -33,18 +36,21 @@ export function useQtData(): UseQtDataReturn {
       setQt(selected);
       setError(null);
 
-      // content가 비어 있으면 Firestore에서 재조회
-      // (App Group → AsyncStorage 경유 시 bible_references가 없는 구 포맷 데이터일 수 있음)
-      if (selected && !selected.content) {
+      // 로컬에 video_url/content가 비면 Firestore 강제 조회로 보충 (onSnapshot은 웜스타트 캐시 시 안 옴).
+      // reconcileFreshDoc로 빈 칸만 머지, 세션당 1회. useSermonData와 동일 동작.
+      if (selected && (!selected.video_url || !selected.content) && !triedServerFill.current) {
+        triedServerFill.current = true;
         try {
           const fresh = await fetchLatestQtFromServer();
-          if (fresh) {
-            await saveQtToAsyncStorage(fresh);
-            setQt(fresh);
-            return fresh;
+          const next = fresh ? reconcileFreshDoc(fresh, selected, compareQt) : null;
+          if (next) {
+            logger.log('[loadLocalData] 로컬 qt video_url/content 누락 → 서버에서 보충함');
+            await saveQtToAsyncStorage(next);
+            setQt(next);
+            return next;
           }
-        } catch (fetchErr) {
-          logger.warn('useQtData: Firestore fallback failed (offline?)', fetchErr);
+        } catch (fillErr) {
+          logger.warn('useQtData: 서버 보충 조회 실패 (offline?)', fillErr);
         }
       }
 

--- a/src/hooks/useSermonData.ts
+++ b/src/hooks/useSermonData.ts
@@ -8,6 +8,7 @@ import {
 } from '../services/sermonService';
 import { logAnalytics } from '../utils/analytics';
 import logger from '../utils/logger';
+import { reconcileFreshDoc } from '../utils/reconcileFreshDoc';
 
 export interface UseSermonDataReturn {
   sermon: Sermon | null;
@@ -25,6 +26,8 @@ export function useSermonData(): UseSermonDataReturn {
   const [error, setError] = useState<string | null>(null);
   const sermonRef = useRef<Sermon | null>(null);
   sermonRef.current = sermon;
+  // video_url/content 보충용 서버 강제 조회를 세션당 1회로 제한 (영상이 원래 없는 설교에서 반복 조회 방지)
+  const triedServerFill = useRef(false);
 
   const loadLocalData = useCallback(async (): Promise<Sermon | null> => {
     try {
@@ -34,6 +37,26 @@ export function useSermonData(): UseSermonDataReturn {
 
       setSermon(selected);
       setError(null);
+
+      // 로컬 데이터에 video_url/content가 비어 있으면 Firestore에서 강제 조회해 보충한다.
+      // onSnapshot은 웜스타트(Firestore 캐시) 시 콜백이 오지 않아 보충이 안 되므로 서버 강제 조회가 필요.
+      // (수동 "데이터 새로고침"과 동일 경로) reconcileFreshDoc로 빈 칸만 머지, 세션당 1회만 시도.
+      if (selected && (!selected.video_url || !selected.content) && !triedServerFill.current) {
+        triedServerFill.current = true;
+        try {
+          const fresh = await fetchLatestSermonFromServer();
+          const next = fresh ? reconcileFreshDoc(fresh, selected, compareSermon) : null;
+          if (next) {
+            logger.log('[loadLocalData] 로컬 video_url/content 누락 → 서버에서 보충함');
+            await saveSermonToAsyncStorage(next);
+            setSermon(next);
+            return next;
+          }
+        } catch (fillErr) {
+          logger.warn('useSermonData: 서버 보충 조회 실패 (offline?)', fillErr);
+        }
+      }
+
       return selected;
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);

--- a/src/utils/reconcileFreshDoc.ts
+++ b/src/utils/reconcileFreshDoc.ts
@@ -1,0 +1,32 @@
+/**
+ * Firestore onSnapshot으로 도착한 fresh 문서를 현재(current)와 비교해
+ * 화면/AsyncStorage에 반영할 문서를 결정한다.
+ *
+ * - fresh가 더 최신(compare > 0)이면 fresh로 통째 교체 (서버가 canonical)
+ * - 같은 날짜(같은 항목)인데 current에 content/video_url이 비어 있으면 fresh 값으로만 보충(머지)
+ *   → 구 캐시 / FCM 페이로드가 video_url을 누락한 경우를 보정한다.
+ *     단 fresh에도 없으면 채우지 않으므로, 영상이 원래 없는 항목에서 불필요한 갱신/루프가 없다.
+ *   → 머지는 빈 칸만 채우고 기존 값은 보존하므로, FCM이 먼저 들고 온 필드를 덮지 않는다.
+ * - 반영할 변화가 없으면 null
+ *
+ * Sermon, QT 양쪽 onSnapshot에서 동일하게 사용해 두 화면 동작을 통일한다.
+ */
+export function reconcileFreshDoc<
+  T extends { date: string; content: string; video_url?: string },
+>(
+  fresh: T,
+  current: T | null,
+  compare: (a: T | null, b: T | null) => number,
+): T | null {
+  if (compare(fresh, current) > 0) return fresh;
+  if (!current || fresh.date !== current.date) return null;
+
+  const merged: T = {
+    ...current,
+    content: current.content || fresh.content,
+    video_url: current.video_url || fresh.video_url,
+  };
+  const changed =
+    merged.content !== current.content || merged.video_url !== current.video_url;
+  return changed ? merged : null;
+}


### PR DESCRIPTION
## 문제
주일말씀(및 매일만나 QT) 유튜브 "바로가기" 버튼이 특정 영상이 아니라 유튜브 채널로 이동.

## 원인
- 캐시(AsyncStorage)에 저장된 설교/QT에 `video_url`이 없을 때 발생 (구 데이터 / FCM 페이로드 누락).
- 데이터가 stale(7일)이 아니면 앱 실행 시 서버 재조회를 건너뜀.
- `onSnapshot`은 웜스타트에서 Firestore 캐시 스냅샷을 skip → 보충 콜백이 오지 않음.
- 결과적으로 `video_url`이 비어 fallback(채널)로 이동. 수동 "데이터 새로고침"(서버 강제 조회) 시에만 채워졌음.

## 수정
- `loadLocalData`에서 `video_url`/`content`가 비면 Firestore 서버 강제 조회로 보충.
  - `reconcileFreshDoc`: 더 최신이면 교체, 같은 날짜면 빈 칸만 머지(기존 값 보존).
  - 세션당 1회 제한 → 영상이 원래 없는 항목에서 반복 조회 방지.
- sermon/QT 양쪽 동일 적용(동작 통일).
- jest crashlytics mock을 모듈러 API에 맞춰 수정(테스트 실행 정상화).

## 테스트
- `reconcileFreshDoc` 단위 8케이스 + `useSermonData` 보충 동작 3케이스 추가 (통과).
- Android 에뮬레이터: `video_url` 없는 시드 → 리로드 시 `[loadLocalData] …보충함` 로그 + 버튼이 영상으로 이동 확인.

## 범위 외 (별도 건)
- "FCM 수신 후 앱 켜둔 상태에서 반영 안 됨(완전 종료 후에만 반영)" = iOS AsyncStorage 메모리 캐시 이슈로 별개.