### PR TITLE
[ISSUE-152] Android 시스템 글자 크기 확대 시 탭/설정 헤더 텍스트 수직 중앙 정렬

### DIFF
--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -153,6 +153,12 @@ const styles = StyleSheet.create({
     fontSize: 20,
     fontFamily: 'Pretendard-Bold',
     color: '#919191',
+    // Android는 폰트 ascent/descent에 따라 비대칭 padding(includeFontPadding)을 더해,
+    // 시스템 글자 크기/굵게 설정 시 글자가 테두리 중앙보다 아래로 쳐진다.
+    // iOS에는 해당 개념이 없어 항상 중앙 정렬된다. Android에서만 padding을 끄고
+    // textAlignVertical로 수직 중앙 정렬을 강제한다(두 속성 모두 iOS에서는 무시됨).
+    includeFontPadding: false,
+    textAlignVertical: 'center',
   },
   tabLabelActive: {
     color: '#00A8DE',

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -307,6 +307,11 @@ const styles = StyleSheet.create({
     fontSize: 20,
     fontFamily: 'Pretendard-SemiBold',
     letterSpacing: -1,
+    // Android는 includeFontPadding으로 비대칭 padding을 더해 시스템 글자 크기/굵게 설정 시
+    // 제목이 헤더 중앙보다 아래로 쳐진다. iOS는 해당 개념이 없어 항상 중앙 정렬된다.
+    // Android에서만 padding을 끄고 수직 중앙 정렬을 강제한다(두 속성 모두 iOS에서는 무시됨).
+    includeFontPadding: false,
+    textAlignVertical: 'center',
   },
   scrollContent: {
     flexGrow: 1,

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -293,7 +293,10 @@ const styles = StyleSheet.create({
     marginHorizontal: 27,
     marginTop: 16,
     marginBottom: 24,
-    height: 30,
+    // height(고정값)로는 시스템 글자 크기 확대 시 제목 텍스트의 실제 렌더링 높이가
+    // 컨테이너를 넘어서며 Android에서 하단이 잘린다(iOS는 넘쳐도 자르지 않아 문제없음).
+    // minHeight로 바꿔 글자 크기에 따라 컨테이너 높이도 함께 늘어나게 한다.
+    minHeight: 30,
   },
   backButton: {
     // 아이콘 주변에 실제 터치 패딩을 더해 탭 영역을 넓힌다(hitSlop과 병행).


### PR DESCRIPTION
## Summary
- Android에서 시스템 글자 크기 최대 + 글꼴 굵게 설정 시, 메인 탭 바("주일 말씀"/"매일 만나")와 설정 화면 헤더("설정") 텍스트가 컨테이너 중앙보다 아래로 쳐지는 문제 수정
- 원인: Android `Text`의 `includeFontPadding`(기본 `true`)이 폰트 ascent/descent에 따라 비대칭 padding을 추가함. iOS는 이 개념이 없어 항상 중앙 정렬됨
- `includeFontPadding: false` + `textAlignVertical: 'center'`를 해당 텍스트 스타일에 추가. 두 속성 모두 Android 전용이라 iOS 렌더링에는 영향 없음

## Test plan
- [x] `tsc --noEmit` 통과
- [ ] Android 기기/에뮬레이터에서 시스템 글자 크기 최대 + 글꼴 굵게 설정 후 메인 탭 바 텍스트가 중앙에 위치하는지 확인
- [ ] 동일 설정에서 설정 화면 헤더 "설정" 텍스트가 중앙에 위치하는지 확인
- [ ] 기본 글자 크기에서도 기존과 동일하게 보이는지 확인 (회귀 없음)
- [ ] iOS에서 기존과 동일하게 정상 표시되는지 확인

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)