### PR TITLE
[ISSUE-154] 위젯 선설치 시 QT 로드 실패 + 새로고침해도 위젯 미갱신 수정

### DIFF
--- a/__tests__/useWidgetSync.test.ts
+++ b/__tests__/useWidgetSync.test.ts
@@ -1,0 +1,40 @@
+import { renderHook } from '@testing-library/react-native';
+import { useWidgetSync } from '../src/hooks/useWidgetSync';
+import WidgetUpdateModule from '../src/types/WidgetUpdateModule';
+import type { Sermon } from '../src/types/Sermon';
+
+jest.mock('../src/utils/logger', () => ({
+  __esModule: true,
+  default: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const mockOnSermonUpdated = WidgetUpdateModule.onSermonUpdated as jest.Mock;
+
+const baseSermon: Sermon = {
+  id: 'sermon-1',
+  title: '오직 성령의 능력으로',
+  content: '본문 : 사도행전 1:8',
+  date: '2026-04-26',
+  created_at: { seconds: 0, nanoseconds: 0 },
+  updated_at: { seconds: 0, nanoseconds: 0 },
+};
+
+describe('useWidgetSync', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sermon이 있으면 onSermonUpdated에 JSON으로 전달', () => {
+    renderHook(() => useWidgetSync(baseSermon));
+
+    expect(mockOnSermonUpdated).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(mockOnSermonUpdated.mock.calls[0][0]);
+    expect(payload.id).toBe('sermon-1');
+    expect(payload.date).toBe('2026-04-26');
+  });
+
+  it('sermon이 null이면 onSermonUpdated 호출 안 함', () => {
+    renderHook(() => useWidgetSync(null));
+    expect(mockOnSermonUpdated).not.toHaveBeenCalled();
+  });
+});

--- a/android/app/src/main/java/app/mannadev/meditation/data/FirestoreBibleReferences.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/data/FirestoreBibleReferences.kt
@@ -1,0 +1,44 @@
+package app.mannadev.meditation.data
+
+import app.mannadev.meditation.model.BibleReferenceResolver
+import org.json.JSONArray
+import org.json.JSONObject
+import timber.log.Timber
+
+/**
+ * 위젯 단독 설치 등으로 prefs가 비어있을 때, 네이티브 Firestore 조회 결과로부터 본문(content)을 만든다.
+ * Firestore 문서는 `bible_references`를 book/chapter/verse_start/verse_end 필드를 가진 배열로 저장하는데,
+ * 이는 FCM data payload에서 [BibleReferenceResolver.resolveBibleReferencesJson]이 받는 JSON 문자열과
+ * 동일한 스키마이므로, 재직렬화만 해서 그대로 재사용한다.
+ */
+internal fun resolveFirestoreContent(
+    resolver: BibleReferenceResolver,
+    data: Map<String, Any?>,
+): String {
+    val fallback = data["content"] as? String ?: ""
+    @Suppress("UNCHECKED_CAST")
+    val bibleReferences = data["bible_references"] as? List<Map<String, Any?>>
+    if (bibleReferences.isNullOrEmpty()) return fallback
+
+    return try {
+        resolver.resolveBibleReferencesJson(bibleReferencesToJson(bibleReferences))
+    } catch (e: Exception) {
+        Timber.w(e, "resolveFirestoreContent: bible_references 변환 실패, content 비움")
+        ""
+    }
+}
+
+private fun bibleReferencesToJson(bibleReferences: List<Map<String, Any?>>): String {
+    val array = JSONArray()
+    bibleReferences.forEach { ref ->
+        array.put(
+            JSONObject().apply {
+                put("book", ref["book"])
+                put("chapter", ref["chapter"])
+                put("verse_start", ref["verse_start"])
+                put("verse_end", ref["verse_end"])
+            },
+        )
+    }
+    return array.toString()
+}

--- a/android/app/src/main/java/app/mannadev/meditation/data/QtFirestoreDataSource.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/data/QtFirestoreDataSource.kt
@@ -1,6 +1,6 @@
 package app.mannadev.meditation.data
 
-import app.mannadev.meditation.dto.SermonDto
+import app.mannadev.meditation.dto.QtDto
 import app.mannadev.meditation.model.BibleReferenceResolver
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
@@ -10,36 +10,38 @@ import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
-class FirestoreFetchException(message: String, cause: Throwable? = null) : Exception(message, cause)
-
 @Singleton
-class SermonFirestoreDataSource @Inject constructor(
+class QtFirestoreDataSource @Inject constructor(
     private val firestore: FirebaseFirestore,
     private val bibleReferenceResolver: BibleReferenceResolver,
 ) {
-    /** 위젯이 prefs 없이 단독 설치됐을 때를 위한 fallback. Firestore에서 최신 설교 1건을 직접 조회한다. */
-    suspend fun fetchLatestSermon(): SermonDto? = withContext(Dispatchers.IO) {
+    /** 위젯이 prefs 없이 단독 설치됐을 때를 위한 fallback. Firestore에서 최신 QT 1건을 직접 조회한다. */
+    suspend fun fetchLatestQt(): QtDto? = withContext(Dispatchers.IO) {
         val snapshot = try {
-            firestore.collection("sermons")
+            firestore.collection("qt")
                 .orderBy("date", Query.Direction.DESCENDING)
                 .limit(1)
                 .get()
                 .await()
         } catch (e: Exception) {
-            throw FirestoreFetchException("Error fetching sermon from Firestore", e)
+            throw FirestoreFetchException("Error fetching QT from Firestore", e)
         }
         if (snapshot.isEmpty) return@withContext null
         val data = snapshot.documents.first().data ?: return@withContext null
 
         val date = data["date"] as? String ?: return@withContext null
         val title = data["title"] as? String ?: return@withContext null
+        @Suppress("UNCHECKED_CAST")
+        val meditationQuestions = (data["meditation_questions"] as? List<String>) ?: emptyList()
 
-        SermonDto(
+        QtDto(
             date = date,
             title = title,
+            seriesTitle = data["series_title"] as? String ?: "",
             content = resolveFirestoreContent(bibleReferenceResolver, data),
             dayOfWeek = data["day_of_week"] as? String ?: "",
             videoUrl = (data["video_url"] as? String)?.takeIf { it.isNotBlank() },
+            meditationQuestions = meditationQuestions,
         )
     }
 }

--- a/android/app/src/main/java/app/mannadev/meditation/data/SermonRepositoryImpl.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/data/SermonRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package app.mannadev.meditation.data
 
+import app.mannadev.meditation.analytics.CrashlyticsHelper
 import app.mannadev.meditation.domain.repository.SermonRepository
 import app.mannadev.meditation.model.Sermon
 import javax.inject.Inject
@@ -11,13 +12,18 @@ class SermonRepositoryImpl @Inject constructor(
     private val firestoreDataSource: SermonFirestoreDataSource
 ) : SermonRepository {
 
-    /**
-     * TODO: Datasource 우선순위: firestore cache, prefs 에서 가져온걸 날짜로 비교 -> firestore server
-     */
     override suspend fun getDisplaySermon(): Sermon? {
-        return prefsDataSource.getDisplaySermon()?.let {
-            Sermon.fromDto(it)
-        }
+        prefsDataSource.getDisplaySermon()?.let { return Sermon.fromDto(it) }
+
+        // prefs가 비어있음 (예: 메인 앱을 한 번도 열지 않고 위젯만 설치한 경우).
+        // Firestore에서 직접 최신 설교를 가져와 prefs를 채운 뒤 반환한다.
+        return runCatching { firestoreDataSource.fetchLatestSermon() }
+            .onFailure { e ->
+                CrashlyticsHelper.recordException(e, "Sermon widget: Firestore fallback fetch failed")
+            }
+            .getOrNull()
+            ?.also { prefsDataSource.saveDisplaySermon(it) }
+            ?.let { Sermon.fromDto(it) }
     }
 
 }

--- a/android/app/src/main/java/app/mannadev/meditation/domain/usecase/GetDisplayQtUseCase.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/domain/usecase/GetDisplayQtUseCase.kt
@@ -1,13 +1,25 @@
 package app.mannadev.meditation.domain.usecase
 
+import app.mannadev.meditation.analytics.CrashlyticsHelper
+import app.mannadev.meditation.data.QtFirestoreDataSource
 import app.mannadev.meditation.data.QtPrefsDataSource
 import app.mannadev.meditation.dto.QtDto
 import javax.inject.Inject
 
 class GetDisplayQtUseCase @Inject constructor(
-    private val prefsDataSource: QtPrefsDataSource
+    private val prefsDataSource: QtPrefsDataSource,
+    private val firestoreDataSource: QtFirestoreDataSource,
 ) {
     suspend operator fun invoke(): QtDto? {
-        return prefsDataSource.getDisplayQt()
+        prefsDataSource.getDisplayQt()?.let { return it }
+
+        // prefs가 비어있음 (예: 메인 앱을 한 번도 열지 않고 위젯만 설치한 경우).
+        // Firestore에서 직접 최신 QT를 가져와 prefs를 채운 뒤 반환한다.
+        return runCatching { firestoreDataSource.fetchLatestQt() }
+            .onFailure { e ->
+                CrashlyticsHelper.recordException(e, "QT widget: Firestore fallback fetch failed")
+            }
+            .getOrNull()
+            ?.also { prefsDataSource.saveDisplayQt(it) }
     }
 }

--- a/src/hooks/useQtWidgetSync.ts
+++ b/src/hooks/useQtWidgetSync.ts
@@ -1,35 +1,12 @@
 import { useEffect } from 'react';
 import { QT } from '../types/QT';
-import WidgetUpdateModule from '../types/WidgetUpdateModule';
+import { pushQtToWidget } from '../services/qtService';
 import logger from '../utils/logger';
 
 export function useQtWidgetSync(qt: QT | null): void {
   useEffect(() => {
     if (!qt) return;
-    if (!WidgetUpdateModule?.onQtUpdated) {
-      logger.error('WidgetUpdateModule.onQtUpdated is not available');
-      return;
-    }
-    let parsedMeditationQuestions: string[] = [];
-    const raw = qt.meditation_questions;
-    if (typeof raw === 'string' && raw) {
-      try {
-        const parsed = JSON.parse(raw);
-        if (Array.isArray(parsed)) {
-          parsedMeditationQuestions = parsed.filter((q: unknown) => typeof q === 'string') as string[];
-        } else if (typeof parsed === 'string') {
-          parsedMeditationQuestions = parsed.split('\n').filter(Boolean);
-        }
-      } catch {
-        // FCM 경로: meditation_questions가 한국어 평문인 경우
-        parsedMeditationQuestions = raw.split('\n').filter(Boolean);
-      }
-    }
-    const payload = {
-      ...qt,
-      meditation_questions: parsedMeditationQuestions,
-    };
-    WidgetUpdateModule.onQtUpdated(JSON.stringify(payload)).catch((error) => {
+    pushQtToWidget(qt).catch((error) => {
       logger.error('Failed to update QT widget:', error);
     });
   }, [qt]);

--- a/src/hooks/useWidgetSync.ts
+++ b/src/hooks/useWidgetSync.ts
@@ -1,18 +1,13 @@
 import { useEffect } from 'react';
 import { Sermon } from '../types/Sermon';
-import WidgetUpdateModule from '../types/WidgetUpdateModule';
+import { pushSermonToWidget } from '../services/sermonService';
 import logger from '../utils/logger';
 
 export function useWidgetSync(sermon: Sermon | null): void {
   useEffect(() => {
     if (!sermon) return;
-    if (!WidgetUpdateModule) {
-      logger.error('WidgetUpdateModule is not available');
-      return;
-    }
-
     logger.log('[useWidgetSync] onSermonUpdated called, date=' + sermon.date);
-    WidgetUpdateModule.onSermonUpdated(JSON.stringify(sermon)).catch((error) => {
+    pushSermonToWidget(sermon).catch((error) => {
       logger.error('Failed to update widget:', error);
     });
   }, [sermon]);

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -27,8 +27,8 @@ import { RootStackParamList } from '../types/navigation';
 import { FCM_SERMON_KEY } from '../types/Sermon';
 import { FCM_QT_KEY } from '../types/QT';
 import WidgetUpdateModule from '../types/WidgetUpdateModule';
-import { fetchLatestSermonFromServer } from '../services/sermonService';
-import { fetchLatestQtFromServer } from '../services/qtService';
+import { fetchLatestSermonFromServer, pushSermonToWidget } from '../services/sermonService';
+import { fetchLatestQtFromServer, pushQtToWidget } from '../services/qtService';
 import { logAnalytics } from '../utils/analytics';
 import logger from '../utils/logger';
 
@@ -84,7 +84,14 @@ const SettingsScreen = ({ navigation }: Props) => {
       await AsyncStorage.multiRemove(keysToRemove);
       if (sermon) await AsyncStorage.setItem(FCM_SERMON_KEY, JSON.stringify(sermon));
       if (qt) await AsyncStorage.setItem(FCM_QT_KEY, JSON.stringify(qt));
-      if (WidgetUpdateModule) await WidgetUpdateModule.onClear();
+      await Promise.all([
+        sermon
+          ? pushSermonToWidget(sermon).catch((e) => logger.error('위젯(설교) 갱신 실패:', e))
+          : Promise.resolve(),
+        qt
+          ? pushQtToWidget(qt).catch((e) => logger.error('위젯(QT) 갱신 실패:', e))
+          : Promise.resolve(),
+      ]);
       Alert.alert('완료', '데이터를 새로 불러왔습니다.');
     } catch (error) {
       logger.error('Error refreshing data:', error);

--- a/src/services/qtService.ts
+++ b/src/services/qtService.ts
@@ -82,6 +82,33 @@ export function subscribeToLatestQt(
   );
 }
 
+export async function pushQtToWidget(qt: QT): Promise<void> {
+  if (!WidgetUpdateModule?.onQtUpdated) {
+    logger.error('WidgetUpdateModule.onQtUpdated is not available');
+    return;
+  }
+  let parsedMeditationQuestions: string[] = [];
+  const raw = qt.meditation_questions;
+  if (typeof raw === 'string' && raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        parsedMeditationQuestions = parsed.filter((q: unknown) => typeof q === 'string') as string[];
+      } else if (typeof parsed === 'string') {
+        parsedMeditationQuestions = parsed.split('\n').filter(Boolean);
+      }
+    } catch {
+      // FCM 경로: meditation_questions가 한국어 평문인 경우
+      parsedMeditationQuestions = raw.split('\n').filter(Boolean);
+    }
+  }
+  const payload = {
+    ...qt,
+    meditation_questions: parsedMeditationQuestions,
+  };
+  await WidgetUpdateModule.onQtUpdated(JSON.stringify(payload));
+}
+
 export async function fetchLatestQtFromServer(): Promise<QT | null> {
   const db = getFirestore();
   const q = query(collection(db, 'qt'), orderBy('date', 'desc'), limit(1));

--- a/src/services/sermonService.ts
+++ b/src/services/sermonService.ts
@@ -65,6 +65,14 @@ export async function saveSermonToAsyncStorage(sermon: Sermon): Promise<void> {
   await AsyncStorage.setItem(FCM_SERMON_KEY, JSON.stringify(sermon));
 }
 
+export async function pushSermonToWidget(sermon: Sermon): Promise<void> {
+  if (!WidgetUpdateModule?.onSermonUpdated) {
+    logger.error('WidgetUpdateModule.onSermonUpdated is not available');
+    return;
+  }
+  await WidgetUpdateModule.onSermonUpdated(JSON.stringify(sermon));
+}
+
 export async function fetchLatestSermonFromServer(): Promise<Sermon | null> {
   const db = getFirestore();
   const q = query(


### PR DESCRIPTION
## 요약

- 설정 화면의 "데이터 새로고침"이 새로 받아온 데이터를 위젯에 반영하지 않던 버그 수정 (`onClear()`만 호출 → QT 위젯은 전혀 갱신 안 됨, 설교 위젯은 prefs만 비워짐)
- 메인 앱을 한 번도 열지 않고 위젯만 설치해도 최신 QT/설교 내용이 표시되도록 네이티브 Firestore fallback 추가

Closes #154

## 변경 내용

### 1) 새로고침 버튼이 위젯을 갱신하지 않던 버그
- `useWidgetSync`/`useQtWidgetSync`의 위젯 푸시 로직을 `pushSermonToWidget`/`pushQtToWidget`(서비스 레이어)으로 추출
- `SettingsScreen.clearAndRefreshStorage`가 `WidgetUpdateModule.onClear()` 대신 새로 받아온 데이터로 `pushSermonToWidget`/`pushQtToWidget`을 호출하도록 변경

### 2) 위젯 단독 설치 시 에러 화면 fallback
- `GetDisplayQtUseCase`, `SermonRepositoryImpl`(기존에 있던 TODO)이 prefs가 비어있을 때 `QtFirestoreDataSource`/`SermonFirestoreDataSource`로 Firestore에서 최신 문서를 직접 조회하도록 수정
- 조회 결과는 prefs에도 저장해 다음부터는 네트워크 조회 없이 즉시 표시됨 (자가 치유)
- `bible_references` 변환은 FCM data payload와 동일한 스키마를 그대로 재사용 (`BibleReferenceResolver.resolveBibleReferencesJson`)
- 네트워크 실패 시 Crashlytics에 기록 후 null 반환 → 위젯은 기존 에러 화면 그대로 표시 (회귀 없음)

## 테스트

- Android: `./gradlew :app:compileDebugKotlin`, `./gradlew :app:testDebugUnitTest` 통과
- JS: 관련 유닛테스트 통과 (`useWidgetSync`, `useQtWidgetSync`, `qtService`, `sermonService`) — 새 테스트 파일 `__tests__/useWidgetSync.test.ts` 추가
- 리포지토리 전반에 기존부터 있던 무관한 실패(테스트 인프라 mock 누락, ESLint v9 설정 파일 부재)는 이번 변경과 무관함을 main 기준으로 별도 확인함

## 테스트 플랜 (리뷰어용)

- [ ] 기기에서 앱 삭제 후 재설치, **메인 앱을 열지 않은 채** 홈 화면에 "매일 만나"/"주일 말씀" 위젯 추가 → 에러 대신 최신 내용이 표시되는지 확인
- [ ] 설정 > "데이터 새로고침" 클릭 → 위젯이 즉시(수 초 내) 갱신되는지 확인
- [ ] Firestore/네트워크 오프라인 상태에서 위젯 단독 설치 시 기존과 동일하게 에러 화면이 표시되는지 (회귀 없음) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
