### PR TITLE
[ISSUE-154] 위젯 최초 설치 fallback 강화 + 새로고침 즉시 반영 + 최초 실행 안내

### DIFF
--- a/android/app/src/main/java/app/mannadev/meditation/Constants.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/Constants.kt
@@ -20,4 +20,8 @@ object Constants {
     const val DEEP_LINK_DAILY_MANNA = "meditationblossom://open?tab=daily_manna"
 
     const val WIDGET_ERROR_GUIDE_MESSAGE = "묵상만개 앱 설정탭에서 데이터 새로고침 버튼을 눌러주세요"
+
+    const val WIDGET_FIRST_LAUNCH_TITLE = "말씀 위젯 설치 완료!"
+    const val WIDGET_FIRST_LAUNCH_GUIDE_MESSAGE =
+        "묵상만개 앱을 한 번 실행해서 위젯을 활성화 해주세요. 말씀이 자동으로 업데이트 됩니다."
 }

--- a/android/app/src/main/java/app/mannadev/meditation/Constants.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/Constants.kt
@@ -18,4 +18,6 @@ object Constants {
 
     const val DEEP_LINK_SUNDAY_SERMON = "meditationblossom://open?tab=sunday_sermon"
     const val DEEP_LINK_DAILY_MANNA = "meditationblossom://open?tab=daily_manna"
+
+    const val WIDGET_ERROR_GUIDE_MESSAGE = "묵상만개 앱 설정탭에서 데이터 새로고침 버튼을 눌러주세요"
 }

--- a/android/app/src/main/java/app/mannadev/meditation/MainActivity.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/MainActivity.kt
@@ -1,6 +1,7 @@
 package app.mannadev.meditation
 
 import android.os.Bundle
+import app.mannadev.meditation.data.markAppLaunched
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
@@ -27,5 +28,6 @@ class MainActivity : ReactActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(null)
+        markAppLaunched(this)
     }
 }

--- a/android/app/src/main/java/app/mannadev/meditation/data/AppLaunchState.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/data/AppLaunchState.kt
@@ -1,0 +1,22 @@
+package app.mannadev.meditation.data
+
+import android.content.Context
+import androidx.core.content.edit
+
+private const val PREFS_NAME = "app_launch_prefs"
+private const val KEY_HAS_LAUNCHED = "has_launched"
+
+/** MainActivity가 최초로 실행됐을 때(사용자가 직접 앱을 연 시점) 한 번 기록한다. */
+fun markAppLaunched(context: Context) {
+    context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit {
+        putBoolean(KEY_HAS_LAUNCHED, true)
+    }
+}
+
+/**
+ * 위젯이 데이터를 못 가져왔을 때, "메인 앱을 한 번도 연 적 없어서 아직 활성화 전인 상태"와
+ * "앱은 열었지만 어떤 이유로 데이터를 못 가져온 진짜 에러 상태"를 구분하기 위한 신호.
+ * 전자는 안내 문구를, 후자는 새로고침 유도 문구를 보여줘야 한다.
+ */
+fun hasAppEverLaunched(context: Context): Boolean =
+    context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).getBoolean(KEY_HAS_LAUNCHED, false)

--- a/android/app/src/main/java/app/mannadev/meditation/data/FirestoreBibleReferences.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/data/FirestoreBibleReferences.kt
@@ -1,44 +1,54 @@
 package app.mannadev.meditation.data
 
+import app.mannadev.meditation.analytics.CrashlyticsHelper
 import app.mannadev.meditation.model.BibleReferenceResolver
-import org.json.JSONArray
-import org.json.JSONObject
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.put
 import timber.log.Timber
 
 /**
  * 위젯 단독 설치 등으로 prefs가 비어있을 때, 네이티브 Firestore 조회 결과로부터 본문(content)을 만든다.
- * Firestore 문서는 `bible_references`를 book/chapter/verse_start/verse_end 필드를 가진 배열로 저장하는데,
- * 이는 FCM data payload에서 [BibleReferenceResolver.resolveBibleReferencesJson]이 받는 JSON 문자열과
- * 동일한 스키마이므로, 재직렬화만 해서 그대로 재사용한다.
+ *
+ * Firestore 문서(예: `sermons` 컬렉션)는 이미 완전히 해석된 "본문 : ..." 형식의 `content` 필드를
+ * 갖고 있는 경우가 많으므로 이를 최우선으로 사용한다. `content`가 비어있는 문서(예: `qt` 컬렉션은
+ * `content` 필드 자체가 없음)에 한해서만 `bible_references`(book/chapter/verse_start/verse_end 필드를
+ * 가진 배열; FCM data payload에서 [BibleReferenceResolver.resolveBibleReferencesJson]이 받는 JSON과
+ * 동일한 스키마)로부터 재구성을 시도한다.
  */
 internal fun resolveFirestoreContent(
     resolver: BibleReferenceResolver,
     data: Map<String, Any?>,
 ): String {
-    val fallback = data["content"] as? String ?: ""
+    val existingContent = data["content"] as? String
+    if (!existingContent.isNullOrBlank()) return existingContent
+
     @Suppress("UNCHECKED_CAST")
     val bibleReferences = data["bible_references"] as? List<Map<String, Any?>>
-    if (bibleReferences.isNullOrEmpty()) return fallback
+    if (bibleReferences.isNullOrEmpty()) return existingContent ?: ""
 
     return try {
         resolver.resolveBibleReferencesJson(bibleReferencesToJson(bibleReferences))
     } catch (e: Exception) {
         Timber.w(e, "resolveFirestoreContent: bible_references 변환 실패, content 비움")
+        // Crashlytics 기록 자체가 실패해도(예: 초기화 전) 원래 흐름을 막지 않는다.
+        runCatching {
+            CrashlyticsHelper.recordException(e, "resolveFirestoreContent: bible_references 변환 실패")
+        }
         ""
     }
 }
 
 private fun bibleReferencesToJson(bibleReferences: List<Map<String, Any?>>): String {
-    val array = JSONArray()
-    bibleReferences.forEach { ref ->
-        array.put(
-            JSONObject().apply {
-                put("book", ref["book"])
-                put("chapter", ref["chapter"])
-                put("verse_start", ref["verse_start"])
-                put("verse_end", ref["verse_end"])
-            },
-        )
+    val array = buildJsonArray {
+        bibleReferences.forEach { ref ->
+            addJsonObject {
+                put("book", ref["book"] as? String)
+                put("chapter", (ref["chapter"] as? Number)?.toInt())
+                put("verse_start", (ref["verse_start"] as? Number)?.toInt())
+                put("verse_end", (ref["verse_end"] as? Number)?.toInt())
+            }
+        }
     }
     return array.toString()
 }

--- a/android/app/src/main/java/app/mannadev/meditation/data/FirestoreBibleReferences.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/data/FirestoreBibleReferences.kt
@@ -10,32 +10,31 @@ import timber.log.Timber
 /**
  * 위젯 단독 설치 등으로 prefs가 비어있을 때, 네이티브 Firestore 조회 결과로부터 본문(content)을 만든다.
  *
- * Firestore 문서(예: `sermons` 컬렉션)는 이미 완전히 해석된 "본문 : ..." 형식의 `content` 필드를
- * 갖고 있는 경우가 많으므로 이를 최우선으로 사용한다. `content`가 비어있는 문서(예: `qt` 컬렉션은
- * `content` 필드 자체가 없음)에 한해서만 `bible_references`(book/chapter/verse_start/verse_end 필드를
- * 가진 배열; FCM data payload에서 [BibleReferenceResolver.resolveBibleReferencesJson]이 받는 JSON과
- * 동일한 스키마)로부터 재구성을 시도한다.
+ * `bible_references`(book/chapter/verse_start/verse_end 필드를 가진 배열; FCM data payload에서
+ * [BibleReferenceResolver.resolveBibleReferencesJson]이 받는 JSON과 동일한 스키마)로부터 앱에 내장된
+ * Bible DB를 이용해 재구성하는 것을 최우선으로 한다. Firestore의 `content` 필드는 캐시성 편의 필드라
+ * 스키마에서 나중에 사라질 수 있으므로, `bible_references`가 없거나 재구성에 실패했을 때만 fallback으로
+ * 사용한다.
  */
 internal fun resolveFirestoreContent(
     resolver: BibleReferenceResolver,
     data: Map<String, Any?>,
 ): String {
-    val existingContent = data["content"] as? String
-    if (!existingContent.isNullOrBlank()) return existingContent
+    val existingContent = (data["content"] as? String).orEmpty()
 
     @Suppress("UNCHECKED_CAST")
     val bibleReferences = data["bible_references"] as? List<Map<String, Any?>>
-    if (bibleReferences.isNullOrEmpty()) return existingContent ?: ""
+    if (bibleReferences.isNullOrEmpty()) return existingContent
 
     return try {
         resolver.resolveBibleReferencesJson(bibleReferencesToJson(bibleReferences))
     } catch (e: Exception) {
-        Timber.w(e, "resolveFirestoreContent: bible_references 변환 실패, content 비움")
+        Timber.w(e, "resolveFirestoreContent: bible_references 변환 실패, content 필드로 대체")
         // Crashlytics 기록 자체가 실패해도(예: 초기화 전) 원래 흐름을 막지 않는다.
         runCatching {
             CrashlyticsHelper.recordException(e, "resolveFirestoreContent: bible_references 변환 실패")
         }
-        ""
+        existingContent
     }
 }
 

--- a/android/app/src/main/java/app/mannadev/meditation/data/QtFirestoreDataSource.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/data/QtFirestoreDataSource.kt
@@ -1,5 +1,6 @@
 package app.mannadev.meditation.data
 
+import app.mannadev.meditation.analytics.CrashlyticsHelper
 import app.mannadev.meditation.dto.QtDto
 import app.mannadev.meditation.model.BibleReferenceResolver
 import com.google.firebase.firestore.FirebaseFirestore
@@ -26,11 +27,29 @@ class QtFirestoreDataSource @Inject constructor(
         } catch (e: Exception) {
             throw FirestoreFetchException("Error fetching QT from Firestore", e)
         }
-        if (snapshot.isEmpty) return@withContext null
+        if (snapshot.isEmpty) {
+            CrashlyticsHelper.recordException(
+                FirestoreFetchException("qt collection returned no documents"),
+                "QtFirestoreDataSource: empty snapshot",
+            )
+            return@withContext null
+        }
         val data = snapshot.documents.first().data ?: return@withContext null
 
-        val date = data["date"] as? String ?: return@withContext null
-        val title = data["title"] as? String ?: return@withContext null
+        val date = data["date"] as? String ?: run {
+            CrashlyticsHelper.recordException(
+                FirestoreFetchException("qt doc missing/invalid 'date' field. keys=${data.keys}"),
+                "QtFirestoreDataSource: date field missing",
+            )
+            return@withContext null
+        }
+        val title = data["title"] as? String ?: run {
+            CrashlyticsHelper.recordException(
+                FirestoreFetchException("qt doc missing/invalid 'title' field. keys=${data.keys}"),
+                "QtFirestoreDataSource: title field missing",
+            )
+            return@withContext null
+        }
         @Suppress("UNCHECKED_CAST")
         val meditationQuestions = (data["meditation_questions"] as? List<String>) ?: emptyList()
 

--- a/android/app/src/main/java/app/mannadev/meditation/data/SermonFirestoreDataSource.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/data/SermonFirestoreDataSource.kt
@@ -1,5 +1,6 @@
 package app.mannadev.meditation.data
 
+import app.mannadev.meditation.analytics.CrashlyticsHelper
 import app.mannadev.meditation.dto.SermonDto
 import app.mannadev.meditation.model.BibleReferenceResolver
 import com.google.firebase.firestore.FirebaseFirestore
@@ -28,11 +29,29 @@ class SermonFirestoreDataSource @Inject constructor(
         } catch (e: Exception) {
             throw FirestoreFetchException("Error fetching sermon from Firestore", e)
         }
-        if (snapshot.isEmpty) return@withContext null
+        if (snapshot.isEmpty) {
+            CrashlyticsHelper.recordException(
+                FirestoreFetchException("sermons collection returned no documents"),
+                "SermonFirestoreDataSource: empty snapshot",
+            )
+            return@withContext null
+        }
         val data = snapshot.documents.first().data ?: return@withContext null
 
-        val date = data["date"] as? String ?: return@withContext null
-        val title = data["title"] as? String ?: return@withContext null
+        val date = data["date"] as? String ?: run {
+            CrashlyticsHelper.recordException(
+                FirestoreFetchException("sermon doc missing/invalid 'date' field. keys=${data.keys}"),
+                "SermonFirestoreDataSource: date field missing",
+            )
+            return@withContext null
+        }
+        val title = data["title"] as? String ?: run {
+            CrashlyticsHelper.recordException(
+                FirestoreFetchException("sermon doc missing/invalid 'title' field. keys=${data.keys}"),
+                "SermonFirestoreDataSource: title field missing",
+            )
+            return@withContext null
+        }
 
         SermonDto(
             date = date,

--- a/android/app/src/main/java/app/mannadev/meditation/model/Sermon.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/model/Sermon.kt
@@ -13,11 +13,28 @@ data class Sermon(
 ) {
     companion object Companion {
 
+        /** 데이터는 받았지만(parse 실패 등) 표시할 수 없을 때의 공통 에러 표시. */
         val errorSermon = Sermon(
             verses = listOf("내용을 불러올 수 없습니다.", Constants.WIDGET_ERROR_GUIDE_MESSAGE),
             title = "",
             bookName = ""
         )
+
+        /**
+         * prefs/Firestore 어디서도 데이터를 전혀 못 가져왔을 때 사용한다.
+         * @param hasAppEverLaunched false면 메인 앱을 한 번도 실행한 적이 없다는 뜻이므로
+         * (아직 위젯이 활성화되지 않은 정상적인 상태) 안내 문구를, true면 (앱은 열었지만
+         * 데이터를 못 가져온 진짜 에러) 새로고침 유도 문구를 보여준다.
+         */
+        fun noData(hasAppEverLaunched: Boolean): Sermon = if (hasAppEverLaunched) {
+            errorSermon
+        } else {
+            Sermon(
+                verses = listOf(Constants.WIDGET_FIRST_LAUNCH_GUIDE_MESSAGE),
+                title = Constants.WIDGET_FIRST_LAUNCH_TITLE,
+                bookName = "",
+            )
+        }
 
         fun fromDto(dto: SermonDto): Sermon =
             try {

--- a/android/app/src/main/java/app/mannadev/meditation/model/Sermon.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/model/Sermon.kt
@@ -1,6 +1,7 @@
 package app.mannadev.meditation.model
 
 import app.mannadev.meditation.analytics.CrashlyticsHelper
+import app.mannadev.meditation.Constants
 import app.mannadev.meditation.dto.SermonDto
 import timber.log.Timber
 
@@ -13,7 +14,7 @@ data class Sermon(
     companion object Companion {
 
         val errorSermon = Sermon(
-            verses = listOf("내용을 불러올 수 없습니다."),
+            verses = listOf("내용을 불러올 수 없습니다.", Constants.WIDGET_ERROR_GUIDE_MESSAGE),
             title = "",
             bookName = ""
         )

--- a/android/app/src/main/java/app/mannadev/meditation/rnmodule/WidgetUpdateModule.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/rnmodule/WidgetUpdateModule.kt
@@ -12,6 +12,7 @@ import app.mannadev.meditation.ui.widget.VerseWidgetLarge
 import app.mannadev.meditation.ui.widget.QtWidgetLarge
 import app.mannadev.meditation.ui.widget.QtWidgetSmall
 import app.mannadev.meditation.ui.widget.VerseWidgetSmall
+import app.mannadev.meditation.widget.enqueueWidgetInitialSync
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
@@ -241,6 +242,9 @@ class WidgetUpdateModule(reactContext: ReactApplicationContext) :
         log.d("Updating widgets...")
         VerseWidgetLarge().updateAll(context)
         VerseWidgetSmall().updateAll(context)
+        // updateAll()이 위젯이 에러 상태에 머물러 있을 때 등 드물게 반영되지 않는 경우를
+        // 대비해, WorkManager로 한 번 더 확실하게 재갱신을 예약한다(중복 실행은 KEEP으로 방지).
+        enqueueWidgetInitialSync(context)
     }
 
     private suspend fun updateQtWidgets() {
@@ -248,6 +252,7 @@ class WidgetUpdateModule(reactContext: ReactApplicationContext) :
         log.d("Updating QT widgets...")
         QtWidgetLarge().updateAll(context)
         QtWidgetSmall().updateAll(context)
+        enqueueWidgetInitialSync(context)
     }
 
 }

--- a/android/app/src/main/java/app/mannadev/meditation/service/MyFirebaseMessagingService.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/service/MyFirebaseMessagingService.kt
@@ -24,6 +24,7 @@ import app.mannadev.meditation.ui.widget.VerseWidgetLarge
 import app.mannadev.meditation.ui.widget.QtWidgetLarge
 import app.mannadev.meditation.ui.widget.QtWidgetSmall
 import app.mannadev.meditation.ui.widget.VerseWidgetSmall
+import app.mannadev.meditation.widget.enqueueWidgetInitialSync
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import dagger.hilt.android.AndroidEntryPoint
@@ -120,6 +121,7 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
             VerseWidgetSmall().updateAll(applicationContext)
             AnalyticsHelper.logWidgetUpdated("verse_large")
             AnalyticsHelper.logWidgetUpdated("verse_small")
+            enqueueWidgetInitialSync(applicationContext)
         }.onFailure { e ->
             CrashlyticsHelper.recordException(e, "Failed to update sermon widgets")
         }
@@ -166,6 +168,7 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
             QtWidgetSmall().updateAll(applicationContext)
             AnalyticsHelper.logWidgetUpdated("qt_large")
             AnalyticsHelper.logWidgetUpdated("qt_small")
+            enqueueWidgetInitialSync(applicationContext)
         }.onFailure { e ->
             CrashlyticsHelper.recordException(e, "Failed to update qt widgets")
         }

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetLarge.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetLarge.kt
@@ -24,6 +24,7 @@ import androidx.glance.text.Text
 import app.mannadev.meditation.Constants
 import app.mannadev.meditation.R
 import app.mannadev.meditation.analytics.CrashlyticsHelper
+import app.mannadev.meditation.data.hasAppEverLaunched
 import app.mannadev.meditation.di.getWidgetDependencies
 import app.mannadev.meditation.ui.widget.qt.QtWidgetUiModel
 import app.mannadev.meditation.ui.widget.qt.prefixQuestions
@@ -36,15 +37,18 @@ class QtWidgetLarge : GlanceAppWidget(
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val dependencies = getWidgetDependencies(context)
         val getDisplayQtUseCase = dependencies.getDisplayQtUseCase()
+        val launched = hasAppEverLaunched(context)
         val qt = getDisplayQtUseCase() ?: run {
             Timber.w("QtWidgetLarge: No QT data, using error fallback")
-            CrashlyticsHelper.recordException(
-                IllegalStateException("QtWidgetLarge: getDisplayQtUseCase returned null"),
-                "QT widget displayed error fallback due to missing data"
-            )
+            if (launched) {
+                CrashlyticsHelper.recordException(
+                    IllegalStateException("QtWidgetLarge: getDisplayQtUseCase returned null"),
+                    "QT widget displayed error fallback due to missing data"
+                )
+            }
             null
         }
-        val uiModel = qt?.let(QtWidgetUiModel::fromDto) ?: QtWidgetUiModel.error
+        val uiModel = qt?.let(QtWidgetUiModel::fromDto) ?: QtWidgetUiModel.error(launched)
         val clickAction = widgetClickAction(uiModel.videoUrl, Constants.DEEP_LINK_DAILY_MANNA)
 
         provideContent { QtWidgetLargeContent(uiModel, clickAction) }

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetSmall.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetSmall.kt
@@ -28,6 +28,7 @@ import androidx.glance.unit.ColorProvider
 import app.mannadev.meditation.Constants
 import app.mannadev.meditation.R
 import app.mannadev.meditation.analytics.CrashlyticsHelper
+import app.mannadev.meditation.data.hasAppEverLaunched
 import app.mannadev.meditation.di.getWidgetDependencies
 import app.mannadev.meditation.ui.widget.qt.QtWidgetUiModel
 import app.mannadev.meditation.ui.widget.qt.prefixQuestions
@@ -40,15 +41,18 @@ class QtWidgetSmall : GlanceAppWidget(
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val dependencies = getWidgetDependencies(context)
         val getDisplayQtUseCase = dependencies.getDisplayQtUseCase()
+        val launched = hasAppEverLaunched(context)
         val qt = getDisplayQtUseCase() ?: run {
             Timber.w("QtWidgetSmall: No QT data, using error fallback")
-            CrashlyticsHelper.recordException(
-                IllegalStateException("QtWidgetSmall: getDisplayQtUseCase returned null"),
-                "QT widget displayed error fallback due to missing data"
-            )
+            if (launched) {
+                CrashlyticsHelper.recordException(
+                    IllegalStateException("QtWidgetSmall: getDisplayQtUseCase returned null"),
+                    "QT widget displayed error fallback due to missing data"
+                )
+            }
             null
         }
-        val uiModel = qt?.let(QtWidgetUiModel::fromDto) ?: QtWidgetUiModel.error
+        val uiModel = qt?.let(QtWidgetUiModel::fromDto) ?: QtWidgetUiModel.error(launched)
         val clickAction = widgetClickAction(uiModel.videoUrl, Constants.DEEP_LINK_DAILY_MANNA)
 
         provideContent { QtWidgetSmallContent(uiModel, clickAction) }

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/VerseWidgetLarge.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/VerseWidgetLarge.kt
@@ -24,6 +24,7 @@ import androidx.glance.text.Text
 import app.mannadev.meditation.Constants
 import app.mannadev.meditation.R
 import app.mannadev.meditation.analytics.CrashlyticsHelper
+import app.mannadev.meditation.data.hasAppEverLaunched
 import app.mannadev.meditation.di.getWidgetDependencies
 import app.mannadev.meditation.model.Sermon
 import app.mannadev.meditation.ui.widget.theme.Typography
@@ -35,13 +36,16 @@ class VerseWidgetLarge : GlanceAppWidget(
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val widgetDependencies = getWidgetDependencies(context)
         val getDisplaySermonUseCase = widgetDependencies.getDisplaySermonUseCase()
+        val launched = hasAppEverLaunched(context)
         val verse = getDisplaySermonUseCase() ?: run {
             Timber.w("VerseWidgetLarge: No sermon data available, using error fallback")
-            CrashlyticsHelper.recordException(
-                IllegalStateException("VerseWidgetLarge: getDisplaySermonUseCase returned null"),
-                "Widget displayed error fallback due to missing sermon data"
-            )
-            Sermon.errorSermon
+            if (launched) {
+                CrashlyticsHelper.recordException(
+                    IllegalStateException("VerseWidgetLarge: getDisplaySermonUseCase returned null"),
+                    "Widget displayed error fallback due to missing sermon data"
+                )
+            }
+            Sermon.noData(launched)
         }
         val clickAction = widgetClickAction(verse.videoUrl, Constants.DEEP_LINK_SUNDAY_SERMON)
 

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/VerseWidgetSmall.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/VerseWidgetSmall.kt
@@ -27,6 +27,7 @@ import androidx.glance.text.Text
 import app.mannadev.meditation.Constants
 import app.mannadev.meditation.R
 import app.mannadev.meditation.analytics.CrashlyticsHelper
+import app.mannadev.meditation.data.hasAppEverLaunched
 import app.mannadev.meditation.di.getWidgetDependencies
 import app.mannadev.meditation.model.Sermon
 import app.mannadev.meditation.ui.widget.theme.Typography
@@ -38,13 +39,16 @@ class VerseWidgetSmall : GlanceAppWidget(
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val widgetDependencies = getWidgetDependencies(context)
         val getDisplaySermonUseCase = widgetDependencies.getDisplaySermonUseCase()
+        val launched = hasAppEverLaunched(context)
         val verse = getDisplaySermonUseCase() ?: run {
             Timber.w("VerseWidgetSmall: No sermon data available, using error fallback")
-            CrashlyticsHelper.recordException(
-                IllegalStateException("VerseWidgetSmall: getDisplaySermonUseCase returned null"),
-                "Widget displayed error fallback due to missing sermon data"
-            )
-            Sermon.errorSermon
+            if (launched) {
+                CrashlyticsHelper.recordException(
+                    IllegalStateException("VerseWidgetSmall: getDisplaySermonUseCase returned null"),
+                    "Widget displayed error fallback due to missing sermon data"
+                )
+            }
+            Sermon.noData(launched)
         }
         val clickAction = widgetClickAction(verse.videoUrl, Constants.DEEP_LINK_SUNDAY_SERMON)
 

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/qt/QtWidgetUiModel.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/qt/QtWidgetUiModel.kt
@@ -16,14 +16,30 @@ data class QtWidgetUiModel(
     val videoUrl: String?,
 ) {
     companion object {
-        val error: QtWidgetUiModel = QtWidgetUiModel(
-            title = "QT를 불러오지 못했습니다",
-            dateLabel = "",
-            reference = "",
-            verses = listOf(Constants.WIDGET_ERROR_GUIDE_MESSAGE),
-            questions = emptyList(),
-            videoUrl = null,
-        )
+        /**
+         * @param hasAppEverLaunched 메인 앱을 한 번이라도 실행한 적이 있는지. false면
+         * "아직 활성화 전" 안내를, true면 (앱은 열었지만 데이터를 못 가져온) 새로고침
+         * 유도 안내를 보여준다.
+         */
+        fun error(hasAppEverLaunched: Boolean): QtWidgetUiModel = if (hasAppEverLaunched) {
+            QtWidgetUiModel(
+                title = "QT를 불러오지 못했습니다",
+                dateLabel = "",
+                reference = "",
+                verses = listOf(Constants.WIDGET_ERROR_GUIDE_MESSAGE),
+                questions = emptyList(),
+                videoUrl = null,
+            )
+        } else {
+            QtWidgetUiModel(
+                title = Constants.WIDGET_FIRST_LAUNCH_TITLE,
+                dateLabel = "",
+                reference = "",
+                verses = listOf(Constants.WIDGET_FIRST_LAUNCH_GUIDE_MESSAGE),
+                questions = emptyList(),
+                videoUrl = null,
+            )
+        }
 
         fun fromDto(dto: QtDto): QtWidgetUiModel {
             val titleMerged = if (dto.seriesTitle.isNotBlank())

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/qt/QtWidgetUiModel.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/qt/QtWidgetUiModel.kt
@@ -1,5 +1,6 @@
 package app.mannadev.meditation.ui.widget.qt
 
+import app.mannadev.meditation.Constants
 import app.mannadev.meditation.dto.QtDto
 import app.mannadev.meditation.dto.SermonDto
 import app.mannadev.meditation.model.VerseParser
@@ -19,7 +20,7 @@ data class QtWidgetUiModel(
             title = "QT를 불러오지 못했습니다",
             dateLabel = "",
             reference = "",
-            verses = emptyList(),
+            verses = listOf(Constants.WIDGET_ERROR_GUIDE_MESSAGE),
             questions = emptyList(),
             videoUrl = null,
         )

--- a/android/app/src/main/java/app/mannadev/meditation/widget/QtWidgetLargeReceiver.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/widget/QtWidgetLargeReceiver.kt
@@ -12,6 +12,7 @@ class QtWidgetLargeReceiver : GlanceAppWidgetReceiver() {
     override fun onEnabled(context: Context) {
         super.onEnabled(context)
         AnalyticsHelper.logWidgetInstalled("qt_large")
+        enqueueWidgetInitialSync(context)
     }
 
     override fun onDisabled(context: Context) {

--- a/android/app/src/main/java/app/mannadev/meditation/widget/QtWidgetSmallReceiver.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/widget/QtWidgetSmallReceiver.kt
@@ -12,6 +12,7 @@ class QtWidgetSmallReceiver : GlanceAppWidgetReceiver() {
     override fun onEnabled(context: Context) {
         super.onEnabled(context)
         AnalyticsHelper.logWidgetInstalled("qt_small")
+        enqueueWidgetInitialSync(context)
     }
 
     override fun onDisabled(context: Context) {

--- a/android/app/src/main/java/app/mannadev/meditation/widget/VerseWidgetLargeReceiver.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/widget/VerseWidgetLargeReceiver.kt
@@ -12,6 +12,7 @@ class VerseWidgetLargeReceiver : GlanceAppWidgetReceiver() {
     override fun onEnabled(context: Context) {
         super.onEnabled(context)
         AnalyticsHelper.logWidgetInstalled("verse_large")
+        enqueueWidgetInitialSync(context)
     }
 
     override fun onDisabled(context: Context) {

--- a/android/app/src/main/java/app/mannadev/meditation/widget/VerseWidgetSmallReceiver.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/widget/VerseWidgetSmallReceiver.kt
@@ -12,6 +12,7 @@ class VerseWidgetSmallReceiver : GlanceAppWidgetReceiver() {
     override fun onEnabled(context: Context) {
         super.onEnabled(context)
         AnalyticsHelper.logWidgetInstalled("verse_small")
+        enqueueWidgetInitialSync(context)
     }
 
     override fun onDisabled(context: Context) {

--- a/android/app/src/main/java/app/mannadev/meditation/widget/WidgetInitialSyncWorker.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/widget/WidgetInitialSyncWorker.kt
@@ -1,0 +1,81 @@
+package app.mannadev.meditation.widget
+
+import android.content.Context
+import androidx.glance.appwidget.updateAll
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import app.mannadev.meditation.analytics.CrashlyticsHelper
+import app.mannadev.meditation.di.getWidgetDependencies
+import app.mannadev.meditation.ui.widget.QtWidgetLarge
+import app.mannadev.meditation.ui.widget.QtWidgetSmall
+import app.mannadev.meditation.ui.widget.VerseWidgetLarge
+import app.mannadev.meditation.ui.widget.VerseWidgetSmall
+import java.util.concurrent.TimeUnit
+
+/**
+ * 위젯이 (메인 앱을 한 번도 열지 않은 채) 처음 추가됐을 때, prefs가 비어있으면
+ * `provideGlance()` 내부의 동기적 Firestore fallback이 실패하거나(느린 네트워크,
+ * 콜드 스타트 타임아웃 등) 시간이 걸릴 수 있다. 이 Worker는 그 fallback과 별개로
+ * 동작하는 백업 경로로, WorkManager의 재시도/네트워크 대기를 이용해 데이터가
+ * 준비되는 즉시(또는 재시도 끝에) 위젯을 다시 그린다.
+ *
+ * [GetDisplaySermonUseCase]/[GetDisplayQtUseCase]를 호출하는 것 자체가 prefs가
+ * 비어있을 때 Firestore 조회 + prefs 저장까지 수행하므로, 이 Worker는 그 결과를
+ * 이용해 [updateAll]만 호출하면 된다.
+ */
+class WidgetInitialSyncWorker(
+    context: Context,
+    workerParams: WorkerParameters,
+) : CoroutineWorker(context, workerParams) {
+
+    companion object {
+        const val WORK_NAME = "widget_initial_sync"
+    }
+
+    override suspend fun doWork(): Result {
+        return try {
+            val dependencies = getWidgetDependencies(applicationContext)
+            dependencies.getDisplaySermonUseCase()()
+            dependencies.getDisplayQtUseCase()()
+
+            VerseWidgetLarge().updateAll(applicationContext)
+            VerseWidgetSmall().updateAll(applicationContext)
+            QtWidgetLarge().updateAll(applicationContext)
+            QtWidgetSmall().updateAll(applicationContext)
+
+            Result.success()
+        } catch (e: Exception) {
+            CrashlyticsHelper.recordException(e, "WidgetInitialSyncWorker failed")
+            Result.retry()
+        }
+    }
+}
+
+/**
+ * 위젯이 추가될 때(각 Receiver의 onEnabled) 호출한다. 여러 위젯이 동시에 추가돼도
+ * [ExistingWorkPolicy.KEEP]으로 중복 Firestore 조회를 막는다. 네트워크가 연결된
+ * 뒤에만 실행되고, 실패 시 지수 백오프로 재시도한다.
+ */
+fun enqueueWidgetInitialSync(context: Context) {
+    val request = OneTimeWorkRequestBuilder<WidgetInitialSyncWorker>()
+        .setConstraints(
+            Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build(),
+        )
+        .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+        .build()
+
+    WorkManager.getInstance(context)
+        .enqueueUniqueWork(
+            WidgetInitialSyncWorker.WORK_NAME,
+            ExistingWorkPolicy.KEEP,
+            request,
+        )
+}

--- a/android/app/src/main/java/app/mannadev/meditation/widget/WidgetInitialSyncWorker.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/widget/WidgetInitialSyncWorker.kt
@@ -16,6 +16,8 @@ import app.mannadev.meditation.ui.widget.QtWidgetLarge
 import app.mannadev.meditation.ui.widget.QtWidgetSmall
 import app.mannadev.meditation.ui.widget.VerseWidgetLarge
 import app.mannadev.meditation.ui.widget.VerseWidgetSmall
+import kotlinx.coroutines.delay
+import timber.log.Timber
 import java.util.concurrent.TimeUnit
 
 /**
@@ -36,6 +38,11 @@ class WidgetInitialSyncWorker(
 
     companion object {
         const val WORK_NAME = "widget_initial_sync"
+
+        // 위젯이 에러 상태에 머물러 있던 직후에는 updateAll()을 단 한 번만 호출하는 것으로는
+        // 재렌더가 반영되지 않는 경우가 실기기 테스트에서 관찰됐다(정확한 OS/런처 원인은
+        // 미확인). 짧은 간격으로 여러 번 재호출해 성공 확률을 높인다.
+        private val REDRAW_DELAYS_MS = listOf(0L, 3_000L, 8_000L)
     }
 
     override suspend fun doWork(): Result {
@@ -44,10 +51,14 @@ class WidgetInitialSyncWorker(
             dependencies.getDisplaySermonUseCase()()
             dependencies.getDisplayQtUseCase()()
 
-            VerseWidgetLarge().updateAll(applicationContext)
-            VerseWidgetSmall().updateAll(applicationContext)
-            QtWidgetLarge().updateAll(applicationContext)
-            QtWidgetSmall().updateAll(applicationContext)
+            REDRAW_DELAYS_MS.forEachIndexed { attempt, delayMs ->
+                if (delayMs > 0) delay(delayMs)
+                Timber.d("WidgetInitialSyncWorker: redraw attempt #${attempt + 1}")
+                VerseWidgetLarge().updateAll(applicationContext)
+                VerseWidgetSmall().updateAll(applicationContext)
+                QtWidgetLarge().updateAll(applicationContext)
+                QtWidgetSmall().updateAll(applicationContext)
+            }
 
             Result.success()
         } catch (e: Exception) {

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -5,7 +5,7 @@
     <string name="verse_widget_small_description">이번 주 성경 말씀을 카드형으로 보여줍니다.</string>
     <string name="verse_widget_large_name">이번 주 말씀 (배너형)</string>
     <string name="verse_widget_large_description">이번 주 성경 말씀을 배너형으로 보여줍니다.</string>
-    <string name="widget_error_message">말씀 내용을 불러올 수 없습니다.\n묵상만개 앱 설정탭에서 데이터 새로고침 버튼을 눌러주세요</string>
+    <string name="widget_error_message">말씀 내용을 불러올 수 없습니다.\n묵상만개 앱을 실행하거나, 설정탭에서 데이터 새로고침 버튼을 눌러주세요</string>
     <string name="widget_error_title">묵상만개</string>
     <string name="verse_widget_qt_small_name">매일 만나 (카드형)</string>
     <string name="verse_widget_qt_small_description">오늘의 매일 만나 말씀을 카드형으로 보여줍니다.</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -5,7 +5,7 @@
     <string name="verse_widget_small_description">이번 주 성경 말씀을 카드형으로 보여줍니다.</string>
     <string name="verse_widget_large_name">이번 주 말씀 (배너형)</string>
     <string name="verse_widget_large_description">이번 주 성경 말씀을 배너형으로 보여줍니다.</string>
-    <string name="widget_error_message">말씀 내용을 불러올 수 없습니다.</string>
+    <string name="widget_error_message">말씀 내용을 불러올 수 없습니다.\n묵상만개 앱 설정탭에서 데이터 새로고침 버튼을 눌러주세요</string>
     <string name="widget_error_title">묵상만개</string>
     <string name="verse_widget_qt_small_name">매일 만나 (카드형)</string>
     <string name="verse_widget_qt_small_description">오늘의 매일 만나 말씀을 카드형으로 보여줍니다.</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="verse_widget_small_description">Display this week\'s Bible verse in a card type.</string>
     <string name="verse_widget_large_name">Weekly Verse (Banner)</string>
     <string name="verse_widget_large_description">Display this week\'s Bible verse in a banner type.</string>
-    <string name="widget_error_message">Unable to load verse content.\nPlease open the Meditation Blossom app\'s Settings tab and tap Refresh Data.</string>
+    <string name="widget_error_message">Unable to load verse content.\nPlease open the Meditation Blossom app, or open its Settings tab and tap Refresh Data.</string>
     <string name="widget_error_title">Meditation blossom</string>
 
     <string name="widget_preview_title" translatable="false">기도하면 응답되나요?</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="verse_widget_small_description">Display this week\'s Bible verse in a card type.</string>
     <string name="verse_widget_large_name">Weekly Verse (Banner)</string>
     <string name="verse_widget_large_description">Display this week\'s Bible verse in a banner type.</string>
-    <string name="widget_error_message">Unable to load verse content.</string>
+    <string name="widget_error_message">Unable to load verse content.\nPlease open the Meditation Blossom app\'s Settings tab and tap Refresh Data.</string>
     <string name="widget_error_title">Meditation blossom</string>
 
     <string name="widget_preview_title" translatable="false">기도하면 응답되나요?</string>

--- a/android/app/src/test/java/app/mannadev/meditation/data/FirestoreBibleReferencesTest.kt
+++ b/android/app/src/test/java/app/mannadev/meditation/data/FirestoreBibleReferencesTest.kt
@@ -1,0 +1,69 @@
+package app.mannadev.meditation.data
+
+import app.mannadev.meditation.data.bible.BibleDb
+import app.mannadev.meditation.data.bible.BibleRepository
+import app.mannadev.meditation.model.BibleReferenceResolver
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FirestoreBibleReferencesTest {
+
+    private class FakeBibleDb(
+        private val books: Map<String, Int>,
+        private val verses: Map<Triple<Int, Int, Int>, String>,
+    ) : BibleDb {
+        override fun loadBookIdByName() = books
+        override fun queryRange(bookId: Int, chapter: Int, startVerse: Int, endVerse: Int) =
+            (startVerse..endVerse).mapNotNull { v ->
+                verses[Triple(bookId, chapter, v)]?.let { BibleDb.VerseRow(v, it) }
+            }
+    }
+
+    private fun resolver(): BibleReferenceResolver {
+        val db = FakeBibleDb(
+            books = mapOf("역대하" to 14),
+            verses = mapOf(Triple(14, 33, 10) to "여호와께서 이르시되"),
+        )
+        return BibleReferenceResolver(BibleRepository(db))
+    }
+
+    // 실제 sermons 컬렉션 문서(REST API로 확인)는 content가 이미 완전히 해석된
+    // "본문 : ..." 문자열이고 bible_references도 함께 존재한다. bible_references를
+    // 우선시하면 불필요한 재해석 실패 위험이 생기므로 기존 content를 그대로 써야 한다.
+    @Test fun `기존 content가 있으면 bible_references를 무시하고 그대로 사용`() {
+        val data = mapOf(
+            "content" to "본문 : 역대하 33:10-13 10 여호와께서 므낫세와 그의 백성에게...",
+            "bible_references" to listOf(
+                mapOf("book" to "존재하지않는책", "chapter" to 1, "verse_start" to 1, "verse_end" to 1),
+            ),
+        )
+        val out = resolveFirestoreContent(resolver(), data)
+        assertEquals("본문 : 역대하 33:10-13 10 여호와께서 므낫세와 그의 백성에게...", out)
+    }
+
+    // qt 컬렉션 문서는 content 필드 자체가 없고 bible_references만 있다.
+    @Test fun `content가 없으면 bible_references로부터 재구성`() {
+        val data = mapOf(
+            "bible_references" to listOf(
+                mapOf("book" to "역대하", "chapter" to 33, "verse_start" to 10, "verse_end" to 10),
+            ),
+        )
+        val out = resolveFirestoreContent(resolver(), data)
+        assertEquals("본문 : 역대하 33:10 여호와께서 이르시되", out)
+    }
+
+    @Test fun `content도 bible_references도 없으면 빈 문자열`() {
+        val out = resolveFirestoreContent(resolver(), emptyMap())
+        assertEquals("", out)
+    }
+
+    @Test fun `bible_references 해석 실패 시 빈 문자열로 안전하게 대체`() {
+        val data = mapOf(
+            "bible_references" to listOf(
+                mapOf("book" to "존재하지않는책", "chapter" to 1, "verse_start" to 1, "verse_end" to 1),
+            ),
+        )
+        val out = resolveFirestoreContent(resolver(), data)
+        assertEquals("", out)
+    }
+}

--- a/android/app/src/test/java/app/mannadev/meditation/data/FirestoreBibleReferencesTest.kt
+++ b/android/app/src/test/java/app/mannadev/meditation/data/FirestoreBibleReferencesTest.kt
@@ -27,18 +27,17 @@ class FirestoreBibleReferencesTest {
         return BibleReferenceResolver(BibleRepository(db))
     }
 
-    // 실제 sermons 컬렉션 문서(REST API로 확인)는 content가 이미 완전히 해석된
-    // "본문 : ..." 문자열이고 bible_references도 함께 존재한다. bible_references를
-    // 우선시하면 불필요한 재해석 실패 위험이 생기므로 기존 content를 그대로 써야 한다.
-    @Test fun `기존 content가 있으면 bible_references를 무시하고 그대로 사용`() {
+    // content 필드는 캐시성 편의 필드라 스키마에서 나중에 사라질 수 있으므로,
+    // bible_references가 있으면 content가 있어도 항상 Bible DB에서 재구성한다.
+    @Test fun `content가 있어도 bible_references가 있으면 항상 재구성`() {
         val data = mapOf(
-            "content" to "본문 : 역대하 33:10-13 10 여호와께서 므낫세와 그의 백성에게...",
+            "content" to "이 값은 사용되면 안 됨",
             "bible_references" to listOf(
-                mapOf("book" to "존재하지않는책", "chapter" to 1, "verse_start" to 1, "verse_end" to 1),
+                mapOf("book" to "역대하", "chapter" to 33, "verse_start" to 10, "verse_end" to 10),
             ),
         )
         val out = resolveFirestoreContent(resolver(), data)
-        assertEquals("본문 : 역대하 33:10-13 10 여호와께서 므낫세와 그의 백성에게...", out)
+        assertEquals("본문 : 역대하 33:10 여호와께서 이르시되", out)
     }
 
     // qt 컬렉션 문서는 content 필드 자체가 없고 bible_references만 있다.
@@ -57,7 +56,18 @@ class FirestoreBibleReferencesTest {
         assertEquals("", out)
     }
 
-    @Test fun `bible_references 해석 실패 시 빈 문자열로 안전하게 대체`() {
+    @Test fun `bible_references 해석 실패 시 기존 content로 안전하게 대체`() {
+        val data = mapOf(
+            "content" to "본문 : 역대하 33:10-13 10 여호와께서 므낫세와 그의 백성에게...",
+            "bible_references" to listOf(
+                mapOf("book" to "존재하지않는책", "chapter" to 1, "verse_start" to 1, "verse_end" to 1),
+            ),
+        )
+        val out = resolveFirestoreContent(resolver(), data)
+        assertEquals("본문 : 역대하 33:10-13 10 여호와께서 므낫세와 그의 백성에게...", out)
+    }
+
+    @Test fun `bible_references 해석도 실패하고 content도 없으면 빈 문자열`() {
         val data = mapOf(
             "bible_references" to listOf(
                 mapOf("book" to "존재하지않는책", "chapter" to 1, "verse_start" to 1, "verse_end" to 1),

--- a/android/app/src/test/java/app/mannadev/meditation/model/SermonTest.kt
+++ b/android/app/src/test/java/app/mannadev/meditation/model/SermonTest.kt
@@ -1,0 +1,19 @@
+package app.mannadev.meditation.model
+
+import app.mannadev.meditation.Constants
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SermonTest {
+
+    @Test fun `앱을 실행한 적 있으면 기존 에러 안내를 반환`() {
+        val result = Sermon.noData(hasAppEverLaunched = true)
+        assertEquals(Sermon.errorSermon, result)
+    }
+
+    @Test fun `앱을 실행한 적 없으면 최초 실행 안내를 반환`() {
+        val result = Sermon.noData(hasAppEverLaunched = false)
+        assertEquals(Constants.WIDGET_FIRST_LAUNCH_TITLE, result.title)
+        assertEquals(listOf(Constants.WIDGET_FIRST_LAUNCH_GUIDE_MESSAGE), result.verses)
+    }
+}

--- a/android/app/src/test/java/app/mannadev/meditation/ui/widget/qt/QtWidgetUiModelTest.kt
+++ b/android/app/src/test/java/app/mannadev/meditation/ui/widget/qt/QtWidgetUiModelTest.kt
@@ -1,0 +1,20 @@
+package app.mannadev.meditation.ui.widget.qt
+
+import app.mannadev.meditation.Constants
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class QtWidgetUiModelTest {
+
+    @Test fun `앱을 실행한 적 있으면 기존 에러 안내를 반환`() {
+        val result = QtWidgetUiModel.error(hasAppEverLaunched = true)
+        assertEquals("QT를 불러오지 못했습니다", result.title)
+        assertEquals(listOf(Constants.WIDGET_ERROR_GUIDE_MESSAGE), result.verses)
+    }
+
+    @Test fun `앱을 실행한 적 없으면 최초 실행 안내를 반환`() {
+        val result = QtWidgetUiModel.error(hasAppEverLaunched = false)
+        assertEquals(Constants.WIDGET_FIRST_LAUNCH_TITLE, result.title)
+        assertEquals(listOf(Constants.WIDGET_FIRST_LAUNCH_GUIDE_MESSAGE), result.verses)
+    }
+}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -84,14 +84,14 @@ const SettingsScreen = ({ navigation }: Props) => {
       await AsyncStorage.multiRemove(keysToRemove);
       if (sermon) await AsyncStorage.setItem(FCM_SERMON_KEY, JSON.stringify(sermon));
       if (qt) await AsyncStorage.setItem(FCM_QT_KEY, JSON.stringify(qt));
-      await Promise.all([
-        sermon
-          ? pushSermonToWidget(sermon).catch((e) => logger.error('위젯(설교) 갱신 실패:', e))
-          : Promise.resolve(),
-        qt
-          ? pushQtToWidget(qt).catch((e) => logger.error('위젯(QT) 갱신 실패:', e))
-          : Promise.resolve(),
-      ]);
+      // 두 위젯을 동시에 갱신하면(Promise.all) 네이티브 쪽 위젯 갱신 요청이 겹쳐 일부가
+      // 누락되는 것처럼 보이는 경우가 있어, 순차적으로 호출해 각각 확실히 반영되게 한다.
+      if (sermon) {
+        await pushSermonToWidget(sermon).catch((e) => logger.error('위젯(설교) 갱신 실패:', e));
+      }
+      if (qt) {
+        await pushQtToWidget(qt).catch((e) => logger.error('위젯(QT) 갱신 실패:', e));
+      }
       Alert.alert('완료', '데이터를 새로 불러왔습니다.');
     } catch (error) {
       logger.error('Error refreshing data:', error);


### PR DESCRIPTION
## 요약

이전 PR(#155)에서 다룬 문제의 실기기 재현 테스트 결과를 반영한 후속 수정입니다.

1. **content 재구성 우선순위**: `bible_references`가 있으면 항상 앱 내장 Bible DB로 재구성 (content 필드는 스키마에서 사라질 수 있는 캐시성 필드이므로 fallback으로만 사용)
2. **WorkManager 백업 재시도**: 위젯 추가 시/새로고침 시/FCM 수신 시 모두 `WidgetInitialSyncWorker`를 큐잉해 `updateAll()` 직접 호출이 반영 안 되는 경우를 대비해 0초/3초/8초 간격으로 재시도
3. **새로고침 즉시 반영**: 설정 화면 새로고침이 새 데이터를 실제로 위젯에 push하지 않던 문제 수정 (순차 호출 + WorkManager 백업)
4. **최초 실행 안내 문구**: 메인 앱을 한 번도 안 연 상태에서 위젯만 설치한 경우, 네이티브 전용 fallback만으로는 짧은 시간 안에 데이터가 채워지지 않는 것이 실기기에서 확인되어(Android 백그라운드 실행 제한으로 추정), "말씀 위젯 설치 완료! 앱을 한 번 실행해주세요" 안내로 전환 — 앱을 이미 연 적 있는 진짜 에러 상태와는 구분해서 표시

Closes #154

## 테스트

- Android 컴파일/전체 유닛테스트 통과 (신규 테스트 포함: FirestoreBibleReferencesTest, SermonTest, QtWidgetUiModelTest)
- 실기기(Galaxy, One UI)에서 반복 재현 테스트를 거쳐 반영된 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)
