### PR TITLE
[ISSUE-154] 앱 실행 시 위젯 초기 동기화 worker 발동 (선설치 위젯 미갱신 대응)

### DIFF
--- a/android/app/src/main/java/app/mannadev/meditation/MainActivity.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/MainActivity.kt
@@ -2,6 +2,7 @@ package app.mannadev.meditation
 
 import android.os.Bundle
 import app.mannadev.meditation.data.markAppLaunched
+import app.mannadev.meditation.widget.enqueueWidgetInitialSync
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
@@ -29,5 +30,10 @@ class MainActivity : ReactActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(null)
         markAppLaunched(this)
+        // 위젯을 앱 미실행 상태로 선설치하면 설치 시점(onEnabled/provideGlance)의 Firestore
+        // fallback이 백그라운드 실행 제한으로 서버에 못 닿아 빈 캐시만 받고 안내 문구에 머문다.
+        // 앱을 실제로 연 이 시점(foreground)에는 조회가 성공하므로, 동일한 초기 동기화 worker를
+        // 여기서 한 번 더 발동해 remote fetch → prefs 저장 → 위젯 재렌더 경로를 확실히 태운다.
+        enqueueWidgetInitialSync(this)
     }
 }


### PR DESCRIPTION
## 문제
앱을 실행하지 않은 채 홈 위젯만 선설치하면, 이후 앱을 실행해도 위젯이 갱신되지 않는 현상 (실기기 확정).

## 원인 (조사)
- 위젯 설치 시점(onEnabled/provideGlance)의 Firestore fallback은 **백그라운드 실행 제한**으로 서버에 못 닿아 빈 캐시만 받고 안내 문구에 머문다. (Crashlytics 1.1.11 1위 non-fatal: `fetchLatestSermon/Qt` empty snapshot, processState=BACKGROUND)
- `remote fetch → prefs 저장 → 위젯 재렌더` 배선 자체는 정상이나, 설치 시점엔 첫 링크(remote fetch)가 죽음.
- 앱 실행(launch) 시점에 위젯을 갱신하는 **결정론적 네이티브 트리거가 없었음** — MainActivity/MainApplication.onCreate는 위젯을 건드리지 않고, launch 시 갱신은 JS 데이터 state 변경의 부수효과로만 일어나 타이밍/네트워크에 취약.

## 변경
`MainActivity.onCreate`에 `enqueueWidgetInitialSync(this)` 추가. 앱을 실제로 연 **foreground** 시점에는 Firestore 조회가 성공하므로, 동일한 초기 동기화 worker를 재발동해 `remote fetch → prefs 저장 → updateAll` 경로를 확실히 태운다.

## 검증
- ✅ `:app:compileDebugKotlin` BUILD SUCCESSFUL
- ⏳ 실기기 검증 예정 (선설치 → 앱 실행 → ~10초 내 위젯 갱신 확인). 이 릴리즈로 실기기 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rfeQ6mgDfMBbLRfgwsgFa