### PR TITLE
[ISSUE-160] 위젯 아키텍처 재설계 후 앱 미실행 상태 새로고침 안내 회귀 수정

### DIFF
--- a/android/app/src/main/java/app/mannadev/meditation/MainActivity.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/MainActivity.kt
@@ -1,5 +1,7 @@
 package app.mannadev.meditation
 
+import android.os.Bundle
+import app.mannadev.meditation.data.markAppLaunched
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
@@ -15,4 +17,11 @@ class MainActivity : ReactActivity() {
             mainComponentName,
             DefaultNewArchitectureEntryPoint.fabricEnabled
         )
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(null)
+        // 위젯이 "앱을 한 번도 실행한 적 없어서 아직 동기화를 시도 못 해본 상태"와
+        // "앱은 열었지만 데이터를 못 가져온 진짜 에러 상태"를 구분할 수 있도록 기록한다.
+        markAppLaunched(this)
+    }
 }

--- a/android/app/src/main/java/app/mannadev/meditation/data/AppLaunchState.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/data/AppLaunchState.kt
@@ -1,0 +1,27 @@
+package app.mannadev.meditation.data
+
+import android.content.Context
+import androidx.core.content.edit
+
+private const val PREFS_NAME = "app_launch_prefs"
+private const val KEY_HAS_LAUNCHED = "has_launched"
+
+/** MainActivity가 최초로 실행됐을 때(사용자가 직접 앱을 연 시점) 한 번 기록한다. */
+fun markAppLaunched(context: Context) {
+    context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit {
+        putBoolean(KEY_HAS_LAUNCHED, true)
+    }
+}
+
+/**
+ * 위젯이 데이터를 못 가져왔을 때, "메인 앱을 한 번도 연 적 없어서 아직 동기화를 시도할
+ * 기회조차 없었던 상태"와 "앱은 열었지만(따라서 최소 한 번은 포그라운드에서 동기화를
+ * 시도할 수 있었지만) 어떤 이유로 데이터를 못 가져온 진짜 에러 상태"를 구분하기 위한 신호.
+ * 전자는 "앱을 실행해주세요" 안내를, 후자는 "새로고침" 유도 문구를 보여줘야 한다.
+ *
+ * syncFromRemote() 성공/실패만으로는 이 둘을 구분할 수 없다 — 위젯이 앱 미실행 상태의
+ * 백그라운드 프로세스에서 동기화를 시도하면 네트워크 제약으로 실패하는데, 이 실패는
+ * "진짜 에러"가 아니라 "아직 제대로 시도할 기회가 없었던 것"에 가깝다.
+ */
+fun hasAppEverLaunched(context: Context): Boolean =
+    context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).getBoolean(KEY_HAS_LAUNCHED, false)

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetLarge.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetLarge.kt
@@ -26,6 +26,7 @@ import androidx.glance.text.Text
 import app.mannadev.meditation.Constants
 import app.mannadev.meditation.R
 import app.mannadev.meditation.analytics.CrashlyticsHelper
+import app.mannadev.meditation.data.hasAppEverLaunched
 import app.mannadev.meditation.di.getWidgetDependencies
 import app.mannadev.meditation.ui.widget.qt.QtWidgetUiModel
 import app.mannadev.meditation.ui.widget.qt.prefixQuestions
@@ -38,7 +39,7 @@ class QtWidgetLarge : GlanceAppWidget(
         val qtRepository = getWidgetDependencies(context).qtRepository()
         provideContent {
             val state by qtRepository.qtState.collectAsState()
-            val uiModel = state.toDisplayQtUiModel()
+            val uiModel = state.toDisplayQtUiModel(hasAppEverLaunched(context))
             val clickAction = widgetClickAction(uiModel.videoUrl, Constants.DEEP_LINK_DAILY_MANNA)
             QtWidgetLargeContent(uiModel, clickAction)
         }

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetSmall.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetSmall.kt
@@ -30,6 +30,7 @@ import androidx.glance.unit.ColorProvider
 import app.mannadev.meditation.Constants
 import app.mannadev.meditation.R
 import app.mannadev.meditation.analytics.CrashlyticsHelper
+import app.mannadev.meditation.data.hasAppEverLaunched
 import app.mannadev.meditation.di.getWidgetDependencies
 import app.mannadev.meditation.ui.widget.qt.QtWidgetUiModel
 import app.mannadev.meditation.ui.widget.qt.prefixQuestions
@@ -42,7 +43,7 @@ class QtWidgetSmall : GlanceAppWidget(
         val qtRepository = getWidgetDependencies(context).qtRepository()
         provideContent {
             val state by qtRepository.qtState.collectAsState()
-            val uiModel = state.toDisplayQtUiModel()
+            val uiModel = state.toDisplayQtUiModel(hasAppEverLaunched(context))
             val clickAction = widgetClickAction(uiModel.videoUrl, Constants.DEEP_LINK_DAILY_MANNA)
             QtWidgetSmallContent(uiModel, clickAction)
         }

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/VerseWidgetLarge.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/VerseWidgetLarge.kt
@@ -26,6 +26,7 @@ import androidx.glance.text.Text
 import app.mannadev.meditation.Constants
 import app.mannadev.meditation.R
 import app.mannadev.meditation.analytics.CrashlyticsHelper
+import app.mannadev.meditation.data.hasAppEverLaunched
 import app.mannadev.meditation.di.getWidgetDependencies
 import app.mannadev.meditation.model.Sermon
 import app.mannadev.meditation.ui.widget.theme.Typography
@@ -37,7 +38,7 @@ class VerseWidgetLarge : GlanceAppWidget(
         val sermonRepository = getWidgetDependencies(context).sermonRepository()
         provideContent {
             val state by sermonRepository.sermonState.collectAsState()
-            val sermon = state.toDisplaySermon()
+            val sermon = state.toDisplaySermon(hasAppEverLaunched(context))
             val clickAction = widgetClickAction(sermon.videoUrl, Constants.DEEP_LINK_SUNDAY_SERMON)
             VerseWidgetLargeContent(sermon, clickAction)
         }

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/VerseWidgetSmall.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/VerseWidgetSmall.kt
@@ -29,6 +29,7 @@ import androidx.glance.text.Text
 import app.mannadev.meditation.Constants
 import app.mannadev.meditation.R
 import app.mannadev.meditation.analytics.CrashlyticsHelper
+import app.mannadev.meditation.data.hasAppEverLaunched
 import app.mannadev.meditation.di.getWidgetDependencies
 import app.mannadev.meditation.model.Sermon
 import app.mannadev.meditation.ui.widget.theme.Typography
@@ -40,7 +41,7 @@ class VerseWidgetSmall : GlanceAppWidget(
         val sermonRepository = getWidgetDependencies(context).sermonRepository()
         provideContent {
             val state by sermonRepository.sermonState.collectAsState()
-            val sermon = state.toDisplaySermon()
+            val sermon = state.toDisplaySermon(hasAppEverLaunched(context))
             val clickAction = widgetClickAction(sermon.videoUrl, Constants.DEEP_LINK_SUNDAY_SERMON)
             VerseWidgetSmallContent(sermon, clickAction)
         }

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/WidgetContentStateMapping.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/WidgetContentStateMapping.kt
@@ -9,20 +9,31 @@ import app.mannadev.meditation.widget.state.WidgetContentState
  * 어떤 state든 기존 Content Composable로 그릴 수 있는 [Sermon]으로 변환한다.
  * NoDataYet/Error/Loading도 항상 clickAction이 붙은 정상 Composable 경로를 타므로,
  * 과거 errorUiLayout(네이티브 XML, 클릭 불가)로 빠지는 경로 자체가 없어진다.
+ *
+ * @param hasAppEverLaunched 메인 앱을 한 번이라도 실행한 적이 있는지. false면 아직
+ * 포그라운드에서 동기화를 시도할 기회조차 없었다는 뜻이므로 Data가 아닌 모든 상태를
+ * "최초 실행 안내"로 보여준다. true면 Error/NoDataYet을 "새로고침 유도" 문구로 보여준다.
+ * (syncFromRemote()의 성공/실패만으로는 "아직 시도 안 해봄"과 "시도했지만 실패"를
+ * 구분할 수 없다 — 앱 미실행 상태의 백그라운드 동기화는 네트워크 제약으로 항상
+ * 실패하지만, 이는 진짜 에러가 아니다.)
  */
-fun WidgetContentState<Sermon>.toDisplaySermon(): Sermon = when (this) {
+fun WidgetContentState<Sermon>.toDisplaySermon(hasAppEverLaunched: Boolean): Sermon = when (this) {
     is WidgetContentState.Data -> value
-    is WidgetContentState.Loading, is WidgetContentState.NoDataYet -> Sermon.noData
-    is WidgetContentState.Error -> Sermon.errorSermon
+    is WidgetContentState.Loading -> Sermon.noData
+    is WidgetContentState.NoDataYet, is WidgetContentState.Error ->
+        if (hasAppEverLaunched) Sermon.errorSermon else Sermon.noData
 }
 
 /**
  * 어떤 state든 기존 Content Composable로 그릴 수 있는 [QtWidgetUiModel]로 변환한다.
  * Sermon과 동일하게 NoDataYet/Error/Loading도 항상 clickAction이 붙은 정상 Composable
  * 경로를 타므로, 과거 errorUiLayout(네이티브 XML, 클릭 불가)로 빠지는 경로 자체가 없어진다.
+ *
+ * @param hasAppEverLaunched [toDisplaySermon]과 동일한 목적.
  */
-fun WidgetContentState<QtDto>.toDisplayQtUiModel(): QtWidgetUiModel = when (this) {
+fun WidgetContentState<QtDto>.toDisplayQtUiModel(hasAppEverLaunched: Boolean): QtWidgetUiModel = when (this) {
     is WidgetContentState.Data -> QtWidgetUiModel.fromDto(value)
-    is WidgetContentState.Loading, is WidgetContentState.NoDataYet -> QtWidgetUiModel.noData
-    is WidgetContentState.Error -> QtWidgetUiModel.error
+    is WidgetContentState.Loading -> QtWidgetUiModel.noData
+    is WidgetContentState.NoDataYet, is WidgetContentState.Error ->
+        if (hasAppEverLaunched) QtWidgetUiModel.error else QtWidgetUiModel.noData
 }

--- a/android/app/src/test/java/app/mannadev/meditation/ui/widget/WidgetContentStateMappingTest.kt
+++ b/android/app/src/test/java/app/mannadev/meditation/ui/widget/WidgetContentStateMappingTest.kt
@@ -10,18 +10,31 @@ class WidgetContentStateMappingTest {
 
     private val sampleSermon = Sermon(verses = listOf("본문"), bookName = "마태복음", title = "제목")
 
-    @Test fun `Sermon Data는 그대로 보여준다`() {
-        val result = WidgetContentState.Data(sampleSermon).toDisplaySermon()
-        assertEquals(sampleSermon, result)
+    @Test fun `Sermon Data는 hasAppEverLaunched와 무관하게 그대로 보여준다`() {
+        assertEquals(sampleSermon, WidgetContentState.Data(sampleSermon).toDisplaySermon(true))
+        assertEquals(sampleSermon, WidgetContentState.Data(sampleSermon).toDisplaySermon(false))
     }
 
-    @Test fun `Sermon Loading과 NoDataYet은 최초 실행 안내를 보여준다`() {
-        assertEquals(Sermon.noData, WidgetContentState.Loading.toDisplaySermon())
-        assertEquals(Sermon.noData, WidgetContentState.NoDataYet.toDisplaySermon())
+    @Test fun `Sermon Loading은 hasAppEverLaunched와 무관하게 최초 실행 안내를 보여준다`() {
+        assertEquals(Sermon.noData, WidgetContentState.Loading.toDisplaySermon(true))
+        assertEquals(Sermon.noData, WidgetContentState.Loading.toDisplaySermon(false))
     }
 
-    @Test fun `Sermon Error는 새로고침 유도 문구를 보여준다`() {
-        val result = WidgetContentState.Error(RuntimeException("boom")).toDisplaySermon()
+    @Test fun `Sermon NoDataYet은 앱을 실행한 적 없으면 최초 실행 안내를 보여준다`() {
+        assertEquals(Sermon.noData, WidgetContentState.NoDataYet.toDisplaySermon(false))
+    }
+
+    @Test fun `Sermon NoDataYet은 앱을 실행한 적 있으면 새로고침 유도 문구를 보여준다`() {
+        assertEquals(Sermon.errorSermon, WidgetContentState.NoDataYet.toDisplaySermon(true))
+    }
+
+    @Test fun `Sermon Error는 앱을 실행한 적 없으면 최초 실행 안내를 보여준다`() {
+        val result = WidgetContentState.Error(RuntimeException("boom")).toDisplaySermon(false)
+        assertEquals(Sermon.noData, result)
+    }
+
+    @Test fun `Sermon Error는 앱을 실행한 적 있으면 새로고침 유도 문구를 보여준다`() {
+        val result = WidgetContentState.Error(RuntimeException("boom")).toDisplaySermon(true)
         assertEquals(Sermon.errorSermon, result)
     }
 
@@ -35,18 +48,31 @@ class WidgetContentStateMappingTest {
         meditationQuestions = emptyList(),
     )
 
-    @Test fun `Qt Data는 fromDto로 변환해서 보여준다`() {
-        val result = WidgetContentState.Data(sampleQt).toDisplayQtUiModel()
-        assertEquals("제목", result.title)
+    @Test fun `Qt Data는 hasAppEverLaunched와 무관하게 fromDto로 변환해서 보여준다`() {
+        assertEquals("제목", WidgetContentState.Data(sampleQt).toDisplayQtUiModel(true).title)
+        assertEquals("제목", WidgetContentState.Data(sampleQt).toDisplayQtUiModel(false).title)
     }
 
-    @Test fun `Qt Loading과 NoDataYet은 최초 실행 안내를 보여준다`() {
-        assertEquals("QT 위젯 설치 완료!", WidgetContentState.Loading.toDisplayQtUiModel().title)
-        assertEquals("QT 위젯 설치 완료!", WidgetContentState.NoDataYet.toDisplayQtUiModel().title)
+    @Test fun `Qt Loading은 hasAppEverLaunched와 무관하게 최초 실행 안내를 보여준다`() {
+        assertEquals("QT 위젯 설치 완료!", WidgetContentState.Loading.toDisplayQtUiModel(true).title)
+        assertEquals("QT 위젯 설치 완료!", WidgetContentState.Loading.toDisplayQtUiModel(false).title)
     }
 
-    @Test fun `Qt Error는 새로고침 유도 문구를 보여준다`() {
-        val result = WidgetContentState.Error(RuntimeException("boom")).toDisplayQtUiModel()
+    @Test fun `Qt NoDataYet은 앱을 실행한 적 없으면 최초 실행 안내를 보여준다`() {
+        assertEquals("QT 위젯 설치 완료!", WidgetContentState.NoDataYet.toDisplayQtUiModel(false).title)
+    }
+
+    @Test fun `Qt NoDataYet은 앱을 실행한 적 있으면 새로고침 유도 문구를 보여준다`() {
+        assertEquals("QT를 불러오지 못했습니다", WidgetContentState.NoDataYet.toDisplayQtUiModel(true).title)
+    }
+
+    @Test fun `Qt Error는 앱을 실행한 적 없으면 최초 실행 안내를 보여준다`() {
+        val result = WidgetContentState.Error(RuntimeException("boom")).toDisplayQtUiModel(false)
+        assertEquals("QT 위젯 설치 완료!", result.title)
+    }
+
+    @Test fun `Qt Error는 앱을 실행한 적 있으면 새로고침 유도 문구를 보여준다`() {
+        val result = WidgetContentState.Error(RuntimeException("boom")).toDisplayQtUiModel(true)
         assertEquals("QT를 불러오지 못했습니다", result.title)
     }
 }


### PR DESCRIPTION
## 요약

#159(위젯 데이터 동기화 아키텍처 재설계)에서 위젯의 "최초 실행 안내" vs "새로고침 유도" 문구 판단 기준을 앱 실행 이력(`hasAppEverLaunched`)에서 `syncFromRemote()` 성공/실패로 재정의하면서 `AppLaunchState`가 삭제됐다. 그런데 `Source.SERVER`로 강제 서버 조회하는 Firestore 데이터소스가 앱 미실행 상태(위젯 `onEnabled()`의 백그라운드 프로세스)에서는 네트워크 제약으로 예외를 던지고, 이게 `WidgetContentState.Error`로 처리되면서 "한 번도 시도 안 해봄"과 "시도했지만 실패"를 구분할 수 없게 됐다 — 그 결과 앱을 한 번도 안 연 상태에서도 새로고침 안내가 뜨는 회귀가 발생했다.

Closes #160

## 변경

- `AppLaunchState.kt` 복원 (`markAppLaunched`/`hasAppEverLaunched`)
- `MainActivity.onCreate()`에서 `markAppLaunched(this)` 재호출
- `WidgetContentStateMapping`의 `toDisplaySermon`/`toDisplayQtUiModel`이 `hasAppEverLaunched: Boolean`을 받아 분기:
  - `false`: `Data`가 아니면 항상 최초 실행 안내
  - `true`: `NoDataYet`/`Error`는 새로고침 유도 문구
- 4개 위젯 Composable에서 `hasAppEverLaunched(context)`를 넘기도록 수정

새로 도입된 StateFlow 기반 반응형 아키텍처(`WidgetInitialSyncWorker`/`WidgetPeriodicSyncWorker` 등)는 그대로 유지 — 이번 회귀는 순수하게 문구 판단 기준의 문제였다.

## 테스트

- `:app:compileDebugKotlin` / `:app:testDebugUnitTest` 전부 통과
- `WidgetContentStateMappingTest`에 `hasAppEverLaunched` true/false 조합 케이스 추가

## 테스트 플랜 (실기기)

- [ ] 앱 삭제 후 재설치, **메인 앱을 열지 않은 채** 위젯만 추가 → "위젯 설치 완료! 앱을 한 번 실행해주세요" 안내가 뜨는지 확인
- [ ] 앱을 한 번 실행한 뒤, (네트워크를 끄는 등으로) 동기화를 실패시켰을 때 → "데이터 새로고침 버튼을 눌러주세요" 안내가 뜨는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
