### PR TITLE
[ISSUE-162] 매일만나 말씀 위젯에도 최초 실행 안내 문구 표시

### DIFF
--- a/ios/MeditationBlossomWidget/DailyMannaWidget.swift
+++ b/ios/MeditationBlossomWidget/DailyMannaWidget.swift
@@ -64,13 +64,19 @@ struct QTEntry: TimelineEntry {
   }
 }
 
+// 매일만나 말씀(DailyMannaContentEntryView)과 묵상질문(DailyMannaMeditationEntryView)
+// 위젯이 이 emptyQTEntry를 공유한다. 말씀 위젯은 verses를, 묵상질문 위젯은
+// meditationQuestions를 본문에 표시하므로, 안내 문구를 두 필드 모두에 넣어야
+// 두 위젯 모두에서 보인다.
+private let widgetInstalledGuideMessage = "묵상만개 앱을 한 번 실행해서 위젯을 활성화 해주세요. 내용이 자동으로 업데이트 됩니다"
+
 private let emptyQTEntry = QTEntry(
   date: Date(),
   mergedTitle: "QT 위젯 설치 완료!",
   dateLabel: "",
   reference: "",
-  verses: [],
-  meditationQuestions: ["묵상만개 앱을 한 번 실행해서 위젯을 활성화 해주세요. 내용이 자동으로 업데이트 됩니다"],
+  verses: [widgetInstalledGuideMessage],
+  meditationQuestions: [widgetInstalledGuideMessage],
   isSunday: false,
   videoUrl: nil,
   youtubeLinkEnabled: false


### PR DESCRIPTION
## 요약

매일만나(QT) 위젯의 최초 실행 안내 문구가 묵상질문 위젯에는 정상적으로 뜨지만, 말씀 위젯에는 안 뜨던 문제 수정.

## 원인

`emptyQTEntry`가 안내 문구를 `meditationQuestions`에만 넣고 있었다. 말씀 위젯(`DailyMannaContentEntryView`)은 본문에 `verses`를 표시하는데 이게 빈 배열이라 제목만 뜨고 본문이 비어 보였다. 묵상질문 위젯(`meditationQuestions` 사용)만 정상 노출.

Closes #162

## 변경

`verses`에도 동일한 안내 문구를 넣어 두 위젯 모두에서 보이도록 수정.

## 테스트 플랜 (Mac에서 실기기/시뮬레이터 확인 필요)

- [ ] 앱 삭제 후 재설치, 메인 앱을 열지 않은 채 "매일만나 말씀" 위젯 추가 → 안내 문구가 본문에 표시되는지 확인
- [ ] 같은 상태에서 "매일만나 묵상질문" 위젯도 여전히 정상 표시되는지 확인 (회귀 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
