### PR TITLE
[ISSUE-164] iOS Archive 수동 서명 전환으로 인증서 한도 소진 방지

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -49,11 +49,6 @@ jobs:
         p12-file-base64: ${{ secrets.IOS_DIST_CERT_BASE64 }}
         p12-password: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
 
-    # App Store Connect API 키(.p8)를 파일로 저장 (자동 서명 + 업로드에 사용)
-    - name: Prepare App Store Connect API key
-      run: |
-        echo "${{ secrets.APPSTORE_API_PRIVATE_KEY }}" > "$RUNNER_TEMP/AuthKey.p8"
-
     # Export 단계에서 쓸 배포용(Store) 프로비저닝 프로파일 3개를 설치
     # (Export는 수동 서명으로 처리 → API 키에 Admin 권한이 필요 없음)
     - name: Install provisioning profiles
@@ -97,7 +92,11 @@ jobs:
         </plist>
         EOF
 
-    # 자동 서명으로 아카이브 (-allowProvisioningUpdates 로 위젯/푸시 익스텐션 프로파일까지 자동 처리)
+    # 수동 서명으로 아카이브 (project.pbxproj의 Release 설정이 CODE_SIGN_STYLE=Manual +
+    # 이미 임포트된 배포용 인증서/프로파일을 명시). -allowProvisioningUpdates는 쓰지 않는다 —
+    # 이 옵션이 있으면 로컬 키체인에 딱 맞는 게 없을 때 Xcode가 API로 새 인증서 발급을
+    # 시도하는데, 이게 반복되며 Apple 계정의 인증서 개수 한도를 소진해 빌드가 실패한 적
+    # 있다(ISSUE-164). 수동 서명은 이미 있는 인증서/프로파일만 사용하므로 이 문제가 없다.
     - name: Build archive
       run: |
         xcodebuild \
@@ -107,11 +106,7 @@ jobs:
           -sdk iphoneos \
           -destination 'generic/platform=iOS' \
           -archivePath "$RUNNER_TEMP/app.xcarchive" \
-          clean archive \
-          -allowProvisioningUpdates \
-          -authenticationKeyPath "$RUNNER_TEMP/AuthKey.p8" \
-          -authenticationKeyID "${{ secrets.APPSTORE_API_KEY_ID }}" \
-          -authenticationKeyIssuerID "${{ secrets.APPSTORE_ISSUER_ID }}"
+          clean archive
 
     - name: Export IPA
       run: |

--- a/ios/meditation_blossom.xcodeproj/project.pbxproj
+++ b/ios/meditation_blossom.xcodeproj/project.pbxproj
@@ -925,8 +925,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = meditation_blossom/meditation_blossom.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = FYUDUBX5E5;
 				INFOPLIST_FILE = meditation_blossom/Info.plist;
@@ -943,7 +943,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = mannachurch.meditationblossom;
 				PRODUCT_NAME = meditation_blossom;
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "Meditation Blossom App Store Manual";
 				SWIFT_OBJC_BRIDGING_HEADER = "meditation_blossom-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1017,7 +1017,8 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_ENTITLEMENTS = PushNotificationService/PushNotificationService.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 10;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -1051,6 +1052,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = mannachurch.meditationblossom.PushNotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "Meditation Blossom Push App Store Manual";
 				SKIP_INSTALL = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1130,8 +1132,8 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_ENTITLEMENTS = MeditationBlossomWidgetExtension.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 10;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -1165,7 +1167,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = mannachurch.meditationblossom.MeditationBlossomWidgetExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "Meditation Blossom Widget App Store Manual";
 				SKIP_INSTALL = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
## 요약

v1.1.15 iOS Build가 "Build archive" 단계에서 실패: Apple 계정이 인증서 개수 한도에 도달해 새 "iOS App Development" 인증서/프로파일을 못 만듦.

Closes #164

## 원인

`ios-build.yml`의 Archive 단계가 `-allowProvisioningUpdates` + App Store Connect API 키로 **자동 서명**을 사용하는데, `project.pbxproj`의 3개 타겟(`meditation_blossom`/`PushNotificationService`/`MeditationBlossomWidgetExtension`) Release 설정이 전부 `CODE_SIGN_STYLE = Automatic`이었다. CI를 돌릴 때마다 Xcode가 새 인증서를 발급받으려 시도했고, 반복되며 Apple 계정의 인증서 한도를 소진했다.

Export IPA 단계는 이미 manual 서명(배포용 인증서 + 특정 provisioning profile 이름)으로 여러 버전 동안 문제 없이 동작해왔다 — Archive만 automatic이었다.

## 변경

- `project.pbxproj`: 3개 타겟 Release 설정을 `CODE_SIGN_STYLE = Manual`, `CODE_SIGN_IDENTITY = "Apple Distribution"`로 변경, `ExportOptions.plist`에 이미 있는(검증된) provisioning profile 이름을 `PROVISIONING_PROFILE_SPECIFIER`에 지정. **Debug 설정은 그대로 둠** (로컬 개발 편의성 유지).
- `ios-build.yml`: Archive 단계에서 `-allowProvisioningUpdates`와 API 키 인증 플래그 제거. 더 이상 안 쓰이는 "Prepare App Store Connect API key" 스텝도 제거.

## 참고

이 수정으로 CI가 더 이상 새 인증서를 요청하지 않게 되므로, **인증서 한도 자체는 다시 소진되지 않을 것으로 기대**합니다. 다만 계정이 이미 한도에 도달한 상태라면 (기존에 발급된 인증서 자체는 그대로 쓰는 거라) 이번 수정만으로 바로 빌드가 성공할 가능성이 높지만, 혹시 여전히 실패한다면 Apple Developer Portal에서 오래된 인증서를 revoke해 슬롯을 확보하는 수동 조치가 추가로 필요할 수 있습니다.

## 테스트

- Windows 환경이라 Xcode 빌드 검증은 못 함 — `project.pbxproj`를 라인 단위로 직접 확인해 Debug 설정 미변경, Release 설정만 정확히 변경됐음을 검증
- 실제 검증은 다음 태그 push 시 CI 빌드로 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)
