### PR TITLE
[CHORE] Android targetSdk 36 컴플라이언스 대응

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -54,8 +54,8 @@ android {
         applicationId = "app.mannadev.meditation"
         minSdk = rootProject.extra["minSdkVersion"].toString().toInt()
         targetSdk = rootProject.extra["targetSdkVersion"].toString().toInt()
-        versionCode = 17
-        versionName = "1.1.16"
+        versionCode = 18
+        versionName = "1.1.17"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,8 +1,8 @@
 buildscript {
     extra.apply {
         set("minSdkVersion", 28)
-        set("compileSdkVersion", 35)
-        set("targetSdkVersion", 35)
+        set("compileSdkVersion", 36)
+        set("targetSdkVersion", 36)
         set("ndkVersion", "28.1.13356709")
     }
 

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 #noinspection AndroidGradlePluginVersion. check libs.versions.toml on @react-native/gradle-plugin
-agp = "8.8.0"
+agp = "8.10.0"
 #noinspection NewerVersionAvailable. check libs.versions.toml on @react-native/gradle-plugin
 kotlin = "2.0.21"
 ksp = "2.0.21-1.0.27"


### PR DESCRIPTION
## Summary
- Google Play가 2026-08-31부터 API 36 미만 타겟 앱 업데이트를 차단하는 정책에 대응
- AGP 8.8.0 → 8.10.0 상향 (compileSdk/targetSdk 36을 지원하는 최소 버전, Gradle wrapper 8.11.1 변경 불필요)
- compileSdkVersion/targetSdkVersion 35 → 36
- versionCode 17→18, versionName 1.1.16→1.1.17
- React Native는 0.78.1 그대로 유지 (RN 0.86 업그레이드는 별도 브랜치/PR로 분리 진행 예정 — 이 PR을 RN 업그레이드 완료 여부와 무관하게 먼저 배포하기 위함)

## Test plan
- [x] `./gradlew assembleDebug` 성공
- [x] `./gradlew bundleRelease` 성공 (secrets.properties 사용)
- [ ] API 36 에뮬레이터에서 실제 설치 후 StatusBar/edge-to-edge, 위젯 갱신, FCM 푸시 수신 확인 (머지 전 권장)
- [ ] `yarn test` 실패 9개 스위트는 이 변경과 무관한 기존 이슈 (`.claude/worktrees` 잔여 디렉토리 + RNFirebase mock) — 별도 트래킹 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋
