### PR TITLE
[HOTFIX] iOS Fabric 서드파티 컴포넌트 크래시 수정 (dependencyProvider 누락)

### DIFF
--- a/ios/meditation_blossom/AppDelegate.mm
+++ b/ios/meditation_blossom/AppDelegate.mm
@@ -15,6 +15,7 @@
 #import <arpa/inet.h>
 #import <string.h>
 #import <React/RCTUtils.h>
+#import <ReactAppDependencyProvider/RCTAppDependencyProvider.h>
 
 // Hermes 엔진 확인을 위한 헤더
 #if __has_include(<hermes/hermes.h>)
@@ -84,6 +85,11 @@ static NSString *MBAsyncStorageDirectory(void)
   [FIRApp configure];
   self.moduleName = @"meditation_blossom";
   self.initialProps = @{};
+  // New Architecture(Fabric)에서 react-native-screens/react-native-svg/safe-area-context 등
+  // 서드파티 컴포넌트를 Fabric 네이티브로 등록하기 위해 필요. 이게 없으면 RCTComponentViewFactory가
+  // thirdPartyFabricComponentsProvider를 못 찾아 전부 Legacy View Manager Interop(plain RCTView)로
+  // 빠지고, 그 결과 RCT_EXPORT_VIEW_PROPERTY로 등록된 prop이 setXxx: 리플렉션 디스패치되며 크래시난다.
+  self.dependencyProvider = [RCTAppDependencyProvider new];
 
   [FIRInAppMessaging inAppMessaging].messageDisplaySuppressed = NO;
   [FIRInAppMessaging inAppMessaging].automaticDataCollectionEnabled = YES;

--- a/ios/meditation_blossom/RCTView+ColorFix.m
+++ b/ios/meditation_blossom/RCTView+ColorFix.m
@@ -9,8 +9,15 @@
 //       -view 를 오버라이드하지 않아 legacy interop 경로에서 plain RCTView 가 생성되고,
 //       RCTView 에 setColor: 구현체가 없어 doesNotRecognizeSelector: 크래시 발생.
 //
+// 다만 이 매니저가 애초에 legacy interop 경로로 빠진 진짜 원인은 AppDelegate.mm에
+// `self.dependencyProvider = [RCTAppDependencyProvider new]`가 누락되어 있었기 때문이다.
+// 이게 없으면 RCTComponentViewFactory가 thirdPartyFabricComponentsProvider를 못 찾아
+// react-native-screens/react-native-svg/safe-area-context 등 서드파티 컴포넌트 전부가
+// (실제 Fabric 클래스가 정상 컴파일되어 있어도) legacy interop으로 빠진다.
+// dependencyProvider 연결 후에는 이 카테고리 없이도 크래시가 재현되지 않았다 — 즉 지금은
+// 죽은 코드에 가깝다. 다만 pre-existing 코드라 최소 변경 원칙상 남겨둠. 완전히 제거해도 무방.
+//
 // 이 카테고리는 RCTView 와 그 슈퍼클래스 경로를 커버하도록 UIView 에 setColor: 를 무음 흡수한다.
-// 해당 라이브러리들이 New Architecture 를 완전히 지원하면 제거 가능.
 
 #import <UIKit/UIKit.h>
 


### PR DESCRIPTION
## 무엇이 문제였는가

New Architecture(Fabric) 환경에서 `react-native-screens`, `react-native-svg`, `safe-area-context` 등 서드파티 컴포넌트를 사용하는 화면에서 `-[RCTView setHide:]`, `-[RCTView setOnSheetDetentChanged:]` 등 `unrecognized selector` 크래시가 발생했습니다.

## 근본 원인

`AppDelegate.mm`에 `self.dependencyProvider = [RCTAppDependencyProvider new]` 할당이 누락되어 있었습니다. 이로 인해 `RCTComponentViewFactory`가 `thirdPartyFabricComponentsProvider`를 찾지 못해, 실제로는 정상적으로 컴파일되어 있는 서드파티 Fabric 컴포넌트 클래스가 있음에도 전부 Legacy View Manager Interop 경로(plain `RCTView`)로 빠졌습니다. 그 결과 `RCT_EXPORT_VIEW_PROPERTY`로 등록된 prop이 `setXxx:` 형태로 리플렉션 디스패치되는데, plain `RCTView`에는 해당 setter 구현이 없어 `doesNotRecognizeSelector:` 크래시로 이어졌습니다.

`dependencyProvider`는 RN 0.78.1 기준 `RCTReactNativeFactoryDelegate` 프로토콜에 정의되어 있고(`RCTAppDelegate` → `RCTDefaultReactNativeFactoryDelegate` → 해당 프로토콜 채택), `ReactAppDependencyProvider` pod도 이미 코드젠으로 생성되고 있어(Podfile.lock에 존재) main의 현재 RN 버전과 무관하게 처음부터 누락되어 있던 기존 버그입니다.

## 수정 내용

- `ios/meditation_blossom/AppDelegate.mm`: `RCTAppDependencyProvider.h` import 추가, `didFinishLaunchingWithOptions:`에서 `self.dependencyProvider = [RCTAppDependencyProvider new]` 할당 추가.
- `ios/meditation_blossom/RCTView+ColorFix.m`: 기존 `setColor:` 흡수 코드 주석이 진짜 원인(legacy interop 자체가 아니라 `dependencyProvider` 누락)을 가리키도록 정정. 코드 동작 변경 없음.

원 커밋(`59ecb0d`, `feature/rn-086-upgrade`)의 커밋 메시지에는 "RCTView+ColorFix.m에 임시로 추가했던 25개 setter 흡수 메서드 제거" 내용이 포함되어 있으나, 이는 RN 0.86 업그레이드 브랜치에서의 별도 작업 이력이며 이번에 cherry-pick된 diff에는 포함되어 있지 않습니다 (diff는 주석 수정만 포함). 실제 변경 범위는 위 두 파일, 주석 정정 + 한 줄 추가가 전부입니다.

## 검증 방법

이번 cherry-pick 작업 세션에서는 `pod install` / Xcode 빌드를 직접 수행하지 않았습니다 (범위 밖). 아래는 머지 전 실행해야 할 검증 절차입니다:

1. `cd ios && pod install && cd ..` 후 시뮬레이터에서 리빌드
2. `log stream --predicate 'process == "meditation_blossom"'`로 로그 스트리밍하며 `unrecognized selector` / Legacy Interop 관련 크래시·경고 로그가 없는지 확인
3. MainTabs → SettingsScreen → EditScreen 등 네비게이션 스택 push/pop 반복 시 크래시 없이 정상 동작하는지 확인 (특히 `react-native-screens`/`safe-area-context` 기반 화면 전환)

참고: 동일한 수정 내용은 `feature/rn-086-upgrade` 브랜치(RN 0.86 기준)에서 시뮬레이터(iOS 26.5) 실기기 검증을 이미 거쳤습니다. 다만 그 검증은 RN 0.86 환경 기준이며, main의 RN 0.78.1 환경에서 별도 재검증이 필요합니다.

## 참고

- 원본 커밋: `59ecb0d` (`feature/rn-086-upgrade`, RN 0.78.1→0.86 업그레이드 장기 브랜치)
- 해당 브랜치와는 무관하게, 이 크래시 수정은 독립적인 프로덕션 버그 수정이라 먼저 분리 배포합니다.
- `feature/rn-086-upgrade` 브랜치 자체는 변경하지 않았습니다 (cherry-pick만 수행).

Made with [Orca](https://github.com/stablyai/orca) 🐋
