### PR TITLE
[CHORE] package.json/iOS 버전을 1.1.17로 동기화

### DIFF
--- a/ios/meditation_blossom.xcodeproj/project.pbxproj
+++ b/ios/meditation_blossom.xcodeproj/project.pbxproj
@@ -902,7 +902,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.16;
+				MARKETING_VERSION = 1.1.17;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -935,7 +935,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.16;
+				MARKETING_VERSION = 1.1.17;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -991,7 +991,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.1.16;
+				MARKETING_VERSION = 1.1.17;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = mannachurch.meditationblossom.PushNotificationService;
@@ -1048,7 +1048,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.1.16;
+				MARKETING_VERSION = 1.1.17;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = mannachurch.meditationblossom.PushNotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1104,7 +1104,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.1.16;
+				MARKETING_VERSION = 1.1.17;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = mannachurch.meditationblossom.MeditationBlossomWidgetExtension;
@@ -1163,7 +1163,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.1.16;
+				MARKETING_VERSION = 1.1.17;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = mannachurch.meditationblossom.MeditationBlossomWidgetExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meditation_blossom",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "private": true,
   "codegenConfig": {
     "name": "AppSpecs",


### PR DESCRIPTION
## Summary
- Android versionName(#193에서 1.1.17로 상향)과 package.json/iOS MARKETING_VERSION(1.1.16 방치) 불일치 수정
- v1.1.17 릴리스 태그 전 플랫폼 간 버전 표기 통일

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

Made with [Orca](https://github.com/stablyai/orca) 🐋
