### PR TITLE
[CHORE] Google Play Console AAB 업로드 CI 배선 추가

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -80,3 +80,15 @@ jobs:
         serviceCredentialsFileContent: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
         groups: 내부테스트
         file: android/app/build/outputs/apk/release/app-release.apk
+
+    # PLAY_STORE_SERVICE_ACCOUNT_JSON 시크릿이 등록되기 전까지는 자동으로 스킵된다.
+    # Play Console API access에 서비스 계정을 연결하고 시크릿을 추가하면 다음 태그 푸시부터 동작.
+    - name: Upload AAB to Google Play Console (internal track)
+      if: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON != '' }}
+      uses: r0adkll/upload-google-play@v1
+      with:
+        serviceAccountJsonPlainText: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
+        packageName: app.mannadev.meditation
+        releaseFiles: android/app/build/outputs/bundle/release/app-release.aab
+        track: internal
+        status: completed


### PR DESCRIPTION
## Summary
- android-build.yml에 Play Console(internal 트랙) AAB 업로드 스텝 추가
- `PLAY_STORE_SERVICE_ACCOUNT_JSON` 시크릿이 없으면 자동 스킵 → 기존 태그 릴리스(Firebase App Distribution/TestFlight)에 영향 없음
- 서비스 계정 생성 및 Play Console API access 연결, 시크릿 등록은 별도 진행 필요

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

Made with [Orca](https://github.com/stablyai/orca) 🐋
