### PR TITLE
[HOTFIX] android-build.yml 워크플로 무효화 수정

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -81,10 +81,17 @@ jobs:
         groups: 내부테스트
         file: android/app/build/outputs/apk/release/app-release.apk
 
+    # step-level if:에서 secrets context를 직접 비교하는 것은 GitHub Actions 스키마상
+    # 허용되지 않는다("Unrecognized named-value: 'secrets'"로 워크플로 자체가 무효 처리됨).
+    # run: 스텝에서 값을 먼저 치환해 outputs로 넘기고, 다음 스텝의 if:는 steps 컨텍스트로 검사한다.
+    - name: Check Play Store secret
+      id: play_secret_check
+      run: echo "has_secret=${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON != '' }}" >> "$GITHUB_OUTPUT"
+
     # PLAY_STORE_SERVICE_ACCOUNT_JSON 시크릿이 등록되기 전까지는 자동으로 스킵된다.
     # Play Console API access에 서비스 계정을 연결하고 시크릿을 추가하면 다음 태그 푸시부터 동작.
     - name: Upload AAB to Google Play Console (internal track)
-      if: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON != '' }}
+      if: steps.play_secret_check.outputs.has_secret == 'true'
       uses: r0adkll/upload-google-play@v1
       with:
         serviceAccountJsonPlainText: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}


### PR DESCRIPTION
## Summary
- #196에서 추가한 step-level `if: secrets.X != ''`가 GitHub Actions 스키마상 허용되지 않아("Unrecognized named-value: 'secrets'") 워크플로 파일 자체가 무효 처리됨 (병합 직후 push에서 확인)
- `run:` 스텝에서 값을 먼저 치환해 `outputs`로 넘기고, 다음 스텝의 `if:`는 `steps` 컨텍스트로 비교하도록 수정
- v1.1.17 태그 빌드는 태그 시점 커밋의 워크플로 파일을 사용하므로 영향 없었음 — 다음 태그부터 정상 동작하도록 선제 수정

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

Made with [Orca](https://github.com/stablyai/orca) 🐋
