### PR TITLE
[HOTFIX] iOS Release 번들링 axios crypto resolve 실패 수정

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -54,8 +54,8 @@ android {
         applicationId = "app.mannadev.meditation"
         minSdk = rootProject.extra["minSdkVersion"].toString().toInt()
         targetSdk = rootProject.extra["targetSdkVersion"].toString().toInt()
-        versionCode = 18
-        versionName = "1.1.17"
+        versionCode = 19
+        versionName = "1.1.18"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/ios/meditation_blossom.xcodeproj/project.pbxproj
+++ b/ios/meditation_blossom.xcodeproj/project.pbxproj
@@ -902,7 +902,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.17;
+				MARKETING_VERSION = 1.1.18;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -935,7 +935,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.17;
+				MARKETING_VERSION = 1.1.18;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -991,7 +991,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.1.17;
+				MARKETING_VERSION = 1.1.18;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = mannachurch.meditationblossom.PushNotificationService;
@@ -1048,7 +1048,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.1.17;
+				MARKETING_VERSION = 1.1.18;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = mannachurch.meditationblossom.PushNotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1104,7 +1104,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.1.17;
+				MARKETING_VERSION = 1.1.18;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = mannachurch.meditationblossom.MeditationBlossomWidgetExtension;
@@ -1163,7 +1163,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.1.17;
+				MARKETING_VERSION = 1.1.18;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = mannachurch.meditationblossom.MeditationBlossomWidgetExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/metro.config.js
+++ b/metro.config.js
@@ -63,6 +63,22 @@ const config = {
           type: "sourceFile",
         };
       }
+      /**
+       * axios(sp-react-native-in-app-updates → react-native-siren → apisauce →
+       * axios 의존 체인, 강제 업데이트 기능에 사용)의 package.json은 "main"이
+       * Node.js 전용 빌드(dist/node/axios.cjs, crypto/http 등 Node core 모듈 require)를
+       * 가리키고, RN 호환 빌드(dist/browser/axios.cjs)로의 리다이렉트는 "exports" 맵의
+       * react-native/browser 조건에만 있다. unstable_enablePackageExports를 꺼둔 상태라
+       * 이 조건이 적용되지 않아 Metro가 Node 빌드를 골라 "Unable to resolve module
+       * crypto"로 번들링이 실패한다. axios 진입점만 명시적으로 browser 빌드로 리다이렉트.
+       */
+      if (moduleName === "axios") {
+        return context.resolveRequest(
+          context,
+          "axios/dist/browser/axios.cjs",
+          platform
+        );
+      }
       return context.resolveRequest(context, moduleName, platform);
     },
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meditation_blossom",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "private": true,
   "codegenConfig": {
     "name": "AppSpecs",


### PR DESCRIPTION
## Summary
- v1.1.17 태그 iOS Build 실패(run 30754951014) 원인 수정: axios가 Node.js 전용 빌드로 resolve되어 `crypto` 모듈을 찾지 못해 Metro 번들링이 실패
- 원인: axios package.json이 RN 호환 빌드로의 리다이렉트를 "exports" 맵에만 정의 → #194에서 끈 `unstable_enablePackageExports`의 부작용
- 의존 체인: `sp-react-native-in-app-updates`(강제 업데이트) → `react-native-siren`(iOS 전용) → `apisauce` → `axios`. iOS 전용 경로라 Android는 영향 없었음(v1.1.17 Android Build는 성공)
- metro.config.js에 axios 진입점만 browser 빌드로 리다이렉트하는 resolveRequest 규칙 추가

## Test plan
- [x] `react-native bundle --platform ios --dev false` 로컬 재현 및 해결 확인
- [x] `react-native bundle --platform android --dev false` 회귀 없음 확인
- [ ] 실제 태그 재푸시로 CI iOS Build 성공 확인 (머지 후 진행)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

Made with [Orca](https://github.com/stablyai/orca) 🐋
