### PR TITLE
[CHORE] Play Console 업로드 vars 온오프 게이트 추가

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -84,14 +84,27 @@ jobs:
     # step-level if:에서 secrets context를 직접 비교하는 것은 GitHub Actions 스키마상
     # 허용되지 않는다("Unrecognized named-value: 'secrets'"로 워크플로 자체가 무효 처리됨).
     # run: 스텝에서 값을 먼저 치환해 outputs로 넘기고, 다음 스텝의 if:는 steps 컨텍스트로 검사한다.
-    - name: Check Play Store secret
-      id: play_secret_check
-      run: echo "has_secret=${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON != '' }}" >> "$GITHUB_OUTPUT"
+    #
+    # vars.PLAY_CONSOLE_UPLOAD_ENABLED를 명시적 온오프 스위치로 둔다. Play Console에서
+    # play-console-ci 서비스 계정에 앱 게시 권한을 아직 못 받은 상태라, 시크릿이 있어도
+    # 권한이 없으면 이 스텝이 API 오류로 실패해 워크플로 전체가 "failure"로 표시된다
+    # (Firebase Distribution 등 앞선 스텝은 이미 끝난 뒤라 실제 배포에는 영향 없지만
+    # 보기에 혼란스럽다). 권한을 받기 전까지는 vars 값을 false로 둬서 아예 시도하지
+    # 않도록 하고, 권한 확인되면 `gh variable set PLAY_CONSOLE_UPLOAD_ENABLED --body true`로
+    # 켠다(코드 변경/재태깅 없이 바로 다음 빌드부터 적용됨).
+    - name: Check Play Console upload gate
+      id: play_gate_check
+      run: |
+        enabled="${{ vars.PLAY_CONSOLE_UPLOAD_ENABLED }}"
+        has_secret="${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON != '' }}"
+        if [ "$enabled" = "true" ] && [ "$has_secret" = "true" ]; then
+          echo "should_upload=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "should_upload=false" >> "$GITHUB_OUTPUT"
+        fi
 
-    # PLAY_STORE_SERVICE_ACCOUNT_JSON 시크릿이 등록되기 전까지는 자동으로 스킵된다.
-    # Play Console API access에 서비스 계정을 연결하고 시크릿을 추가하면 다음 태그 푸시부터 동작.
     - name: Upload AAB to Google Play Console (internal track)
-      if: steps.play_secret_check.outputs.has_secret == 'true'
+      if: steps.play_gate_check.outputs.should_upload == 'true'
       uses: r0adkll/upload-google-play@v1
       with:
         serviceAccountJsonPlainText: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}


### PR DESCRIPTION
## Summary
- play-console-ci 서비스 계정이 아직 Play Console 게시 권한을 못 받은 상태 → 시크릿 존재만으로 업로드를 시도하면 권한 오류로 워크플로 전체가 failure로 표시됨
- `vars.PLAY_CONSOLE_UPLOAD_ENABLED`(기본 false, 저장소 변수로 등록 완료)로 명시적 온오프 스위치 추가
- 권한 확인되면 `gh variable set PLAY_CONSOLE_UPLOAD_ENABLED --body true`로 코드 변경 없이 즉시 활성화 가능

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

Made with [Orca](https://github.com/stablyai/orca) 🐋
