### PR TITLE
[ISSUE-173] 매일 만나 긴 본문 페이지네이션 목업 추가

### DIFF
--- a/docs/superpowers/specs/assets/qt-long-passage-before-scroll.svg
+++ b/docs/superpowers/specs/assets/qt-long-passage-before-scroll.svg
@@ -1,0 +1,35 @@
+<svg viewBox="0 0 300 460" xmlns="http://www.w3.org/2000/svg" font-family="sans-serif">
+  <rect width="300" height="460" rx="20" fill="#FFFFFF"/>
+  <rect x="0" y="0" width="300" height="460" rx="20" fill="none" stroke="#E0E0E0"/>
+
+  <text x="20" y="34" fill="#49454F" font-size="15" font-weight="500">묵상만개</text>
+  <text x="280" y="34" fill="#49454F" font-size="15" text-anchor="end">⚙</text>
+
+  <rect x="16" y="48" width="268" height="40" rx="20" fill="#F3F4F9"/>
+  <text x="90" y="72" fill="#919191" font-size="13" text-anchor="middle">주일 말씀</text>
+  <rect x="150" y="52" width="126" height="32" rx="16" fill="#FFFFFF" stroke="#00A8DE" stroke-width="1.5"/>
+  <text x="213" y="72" fill="#00A8DE" font-size="13" font-weight="700" text-anchor="middle">매일 만나</text>
+
+  <line x1="0" y1="98" x2="300" y2="98" stroke="#E0E0E0"/>
+
+  <text x="20" y="128" fill="#747474" font-size="15" font-weight="700">14. 개혁! 좌로나 우로 치우치지 않는 것</text>
+
+  <text x="20" y="158" font-size="13">
+    <tspan fill="#919191">열왕기하 22:2, </tspan><tspan fill="#000000" font-weight="700">열왕기하 23:21-25</tspan><tspan fill="#919191">, 열왕기하 24, 열왕기하 25</tspan>
+  </text>
+  <text x="20" y="176" fill="#A59EAE" font-size="10">↑ 기존 장절 텍스트와 같은 자리·스타일 (선택된 것만 굵게+검정)</text>
+
+  <rect x="20" y="196" width="140" height="26" rx="13" fill="#EBFAFF"/>
+  <text x="90" y="213" fill="#00A8DE" font-size="12" font-weight="500" text-anchor="middle">열왕기하 23:21-25</text>
+
+  <text x="20" y="248" fill="#000000" font-size="13" font-weight="700">21 왕이 뭇 백성에게 명령하여 이르되 이</text>
+  <text x="20" y="268" fill="#000000" font-size="13" font-weight="700">언약책에 기록된 대로 너희의 하나님</text>
+  <text x="20" y="288" fill="#000000" font-size="13" font-weight="700">여호와를 위하여 유월절을 지키라 하매</text>
+  <text x="20" y="316" fill="#000000" font-size="13" font-weight="700">22 사사가 이스라엘을 다스리던 시대부터</text>
+  <text x="20" y="336" fill="#000000" font-size="13" font-weight="700">이스라엘 여러 왕의 시대와…</text>
+
+  <rect x="284" y="200" width="4" height="220" rx="2" fill="#EEEEEE"/>
+  <rect x="284" y="200" width="4" height="55" rx="2" fill="#C9C9CC"/>
+
+  <text x="150" y="440" fill="#A59EAE" font-size="11" text-anchor="middle">알약 4개 이상 → 페이지 스와이프 + 세로 스크롤바</text>
+</svg>

--- a/docs/superpowers/specs/assets/qt-long-passage-sticky-scroll.svg
+++ b/docs/superpowers/specs/assets/qt-long-passage-sticky-scroll.svg
@@ -1,0 +1,37 @@
+<svg viewBox="0 0 300 460" xmlns="http://www.w3.org/2000/svg" font-family="sans-serif">
+  <rect width="300" height="460" rx="20" fill="#FFFFFF"/>
+  <rect x="0" y="0" width="300" height="460" rx="20" fill="none" stroke="#E0E0E0"/>
+
+  <text x="20" y="34" fill="#49454F" font-size="15" font-weight="500">묵상만개</text>
+  <text x="280" y="34" fill="#49454F" font-size="15" text-anchor="end">⚙</text>
+
+  <rect x="16" y="48" width="268" height="40" rx="20" fill="#F3F4F9"/>
+  <text x="90" y="72" fill="#919191" font-size="13" text-anchor="middle">주일 말씀</text>
+  <rect x="150" y="52" width="126" height="32" rx="16" fill="#FFFFFF" stroke="#00A8DE" stroke-width="1.5"/>
+  <text x="213" y="72" fill="#00A8DE" font-size="13" font-weight="700" text-anchor="middle">매일 만나</text>
+
+  <line x1="0" y1="98" x2="300" y2="98" stroke="#E0E0E0"/>
+
+  <rect x="0" y="99" width="300" height="38" fill="#FFFFFF"/>
+  <text x="20" y="122" font-size="13">
+    <tspan fill="#919191">열왕기하 22:2, 열왕기하 23:21-25, </tspan><tspan fill="#000000" font-weight="700">열왕기하 24</tspan><tspan fill="#919191">, 열왕기하 25</tspan>
+  </text>
+  <line x1="0" y1="137" x2="300" y2="137" stroke="#EDEDED"/>
+  <text x="150" y="150" fill="#7A7A7E" font-size="10" text-anchor="middle">sticky — 세그먼트 탭 바로 아래에 고정</text>
+
+  <rect x="20" y="168" width="120" height="26" rx="13" fill="#EBFAFF"/>
+  <text x="80" y="185" fill="#00A8DE" font-size="12" font-weight="500" text-anchor="middle">열왕기하 24장</text>
+
+  <path d="M8 236 l-6 -8 M2 220 l6 -8" stroke="#D9D9D9" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" transform="translate(4,0)"/>
+  <path d="M292 236 l6 -8 M298 220 l-6 -8" stroke="#D9D9D9" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" transform="translate(-4,0)"/>
+
+  <text x="20" y="220" fill="#000000" font-size="13" font-weight="700">17 왕의 숙부 맛다니야를 대신하여 왕으로</text>
+  <text x="20" y="240" fill="#000000" font-size="13" font-weight="700">삼고 그의 이름을 고쳐 시드기야라 하였더라</text>
+  <text x="20" y="268" fill="#000000" font-size="13" font-weight="700">18 시드기야가 왕이 될 때에 나이가</text>
+  <text x="20" y="288" fill="#000000" font-size="13" font-weight="700">스물한 살이라 예루살렘에서 십일 년간…</text>
+
+  <rect x="284" y="172" width="4" height="220" rx="2" fill="#EEEEEE"/>
+  <rect x="284" y="216" width="4" height="55" rx="2" fill="#00A8DE"/>
+
+  <text x="150" y="440" fill="#A59EAE" font-size="11" text-anchor="middle">24장·25장처럼 한 장이 길어도 세로 스크롤바로 이동 편리</text>
+</svg>


### PR DESCRIPTION
## Summary
- 참조가 많거나(4개+) 한 장이 긴 경우(예: 열왕기하 24, 25장)를 위한 매일 만나 화면 목업 2장 추가
- 상단 선택 탭: 기존 장절 텍스트 스타일 유지, 선택된 장절만 굵은 검정
- 스크롤 시 세그먼트 탭 바로 아래에 sticky 고정
- 알약 4개 이상이면 페이지 스와이프, 페이지 내부는 세로 스크롤바로 이동

## Test plan
- [ ] 문서/이미지 리뷰만 필요 (코드 변경 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)