### PR TITLE
[ISSUE-203] 위젯 유튜브 링크 마커 표시 (Android)

### DIFF
--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetLarge.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetLarge.kt
@@ -16,11 +16,13 @@ import androidx.glance.appwidget.lazy.items
 import androidx.glance.appwidget.provideContent
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Column
+import androidx.glance.layout.Row
 import androidx.glance.layout.Spacer
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.height
 import androidx.glance.layout.padding
+import androidx.glance.layout.width
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import app.mannadev.meditation.Constants
@@ -37,11 +39,12 @@ class QtWidgetLarge : GlanceAppWidget(
 ) {
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val qtRepository = getWidgetDependencies(context).qtRepository()
+        val youtubeLinkEnabled = getWidgetDependencies(context).getWidgetPrefs().isEnabled()
         provideContent {
             val state by qtRepository.qtState.collectAsState()
             val uiModel = state.toDisplayQtUiModel(hasAppEverLaunched(context))
             val clickAction = widgetClickAction(uiModel.videoUrl, Constants.DEEP_LINK_DAILY_MANNA)
-            QtWidgetLargeContent(uiModel, clickAction)
+            QtWidgetLargeContent(uiModel, clickAction, youtubeLinkEnabled)
         }
     }
 
@@ -67,7 +70,7 @@ private object VerseLargeQtDimens {
 }
 
 @Composable
-private fun QtWidgetLargeContent(ui: QtWidgetUiModel, clickAction: Action) {
+private fun QtWidgetLargeContent(ui: QtWidgetUiModel, clickAction: Action, youtubeLinkEnabled: Boolean) {
     Column(
         modifier = GlanceModifier
             .fillMaxSize()
@@ -91,11 +94,21 @@ private fun QtWidgetLargeContent(ui: QtWidgetUiModel, clickAction: Action) {
                 )
                 Spacer(GlanceModifier.height(VerseLargeQtDimens.dateLabelBottomGap))
             }
-            Text(
-                text = ui.title,
-                style = Typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-                maxLines = 2,
-            )
+            Row(
+                modifier = GlanceModifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    modifier = GlanceModifier.defaultWeight(),
+                    text = ui.title,
+                    style = Typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                    maxLines = 2,
+                )
+                if (youtubeLinkEnabled) {
+                    Spacer(GlanceModifier.width(6.dp))
+                    YoutubeMarker()
+                }
+            }
         }
         LazyColumn(GlanceModifier.fillMaxWidth().defaultWeight()) {
             if (ui.reference.isNotBlank()) {

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetSmall.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetSmall.kt
@@ -19,11 +19,13 @@ import androidx.glance.background
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
 import androidx.glance.layout.Column
+import androidx.glance.layout.Row
 import androidx.glance.layout.Spacer
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.height
 import androidx.glance.layout.padding
+import androidx.glance.layout.width
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
@@ -41,11 +43,12 @@ class QtWidgetSmall : GlanceAppWidget(
 ) {
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val qtRepository = getWidgetDependencies(context).qtRepository()
+        val youtubeLinkEnabled = getWidgetDependencies(context).getWidgetPrefs().isEnabled()
         provideContent {
             val state by qtRepository.qtState.collectAsState()
             val uiModel = state.toDisplayQtUiModel(hasAppEverLaunched(context))
             val clickAction = widgetClickAction(uiModel.videoUrl, Constants.DEEP_LINK_DAILY_MANNA)
-            QtWidgetSmallContent(uiModel, clickAction)
+            QtWidgetSmallContent(uiModel, clickAction, youtubeLinkEnabled)
         }
     }
 
@@ -71,7 +74,7 @@ private object VerseSmallQtDimens {
 }
 
 @Composable
-private fun QtWidgetSmallContent(ui: QtWidgetUiModel, clickAction: Action) {
+private fun QtWidgetSmallContent(ui: QtWidgetUiModel, clickAction: Action, youtubeLinkEnabled: Boolean) {
     Column(
         modifier = GlanceModifier
             .fillMaxSize()
@@ -81,15 +84,26 @@ private fun QtWidgetSmallContent(ui: QtWidgetUiModel, clickAction: Action) {
         horizontalAlignment = Alignment.Start,
         verticalAlignment = Alignment.Top
     ) {
-        Text(
-            modifier = GlanceModifier.padding(
-                horizontal = VerseSmallQtDimens.horizontalPadding,
-                vertical = VerseSmallQtDimens.appBarVerticalPadding,
-            ),
-            text = ui.title,
-            style = Typography.titleMedium,
-            maxLines = 2,
-        )
+        Row(
+            modifier = GlanceModifier
+                .fillMaxWidth()
+                .padding(
+                    horizontal = VerseSmallQtDimens.horizontalPadding,
+                    vertical = VerseSmallQtDimens.appBarVerticalPadding,
+                ),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                modifier = GlanceModifier.defaultWeight(),
+                text = ui.title,
+                style = Typography.titleMedium,
+                maxLines = 2,
+            )
+            if (youtubeLinkEnabled) {
+                Spacer(GlanceModifier.width(6.dp))
+                YoutubeMarker()
+            }
+        }
         Box(
             GlanceModifier
                 .padding(horizontal = VerseSmallQtDimens.widgetPadding)

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/VerseWidgetLarge.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/VerseWidgetLarge.kt
@@ -16,11 +16,13 @@ import androidx.glance.appwidget.lazy.items
 import androidx.glance.appwidget.provideContent
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Column
+import androidx.glance.layout.Row
 import androidx.glance.layout.Spacer
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.height
 import androidx.glance.layout.padding
+import androidx.glance.layout.width
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import app.mannadev.meditation.Constants
@@ -36,11 +38,12 @@ class VerseWidgetLarge : GlanceAppWidget(
 ) {
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val sermonRepository = getWidgetDependencies(context).sermonRepository()
+        val youtubeLinkEnabled = getWidgetDependencies(context).getWidgetPrefs().isEnabled()
         provideContent {
             val state by sermonRepository.sermonState.collectAsState()
             val sermon = state.toDisplaySermon(hasAppEverLaunched(context))
             val clickAction = widgetClickAction(sermon.videoUrl, Constants.DEEP_LINK_SUNDAY_SERMON)
-            VerseWidgetLargeContent(sermon, clickAction)
+            VerseWidgetLargeContent(sermon, clickAction, youtubeLinkEnabled)
         }
     }
 
@@ -72,7 +75,7 @@ private object VerseLargeWidgetDimens {
  * @param sermon The [Sermon] object containing the data to be displayed.
  */
 @Composable
-private fun VerseWidgetLargeContent(sermon: Sermon, clickAction: Action) {
+private fun VerseWidgetLargeContent(sermon: Sermon, clickAction: Action, youtubeLinkEnabled: Boolean) {
 
     Column(
         modifier = GlanceModifier
@@ -92,11 +95,21 @@ private fun VerseWidgetLargeContent(sermon: Sermon, clickAction: Action) {
                 ),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text(
-                text = sermon.title,
-                style = Typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-                maxLines = 2
-            )
+            Row(
+                modifier = GlanceModifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    modifier = GlanceModifier.defaultWeight(),
+                    text = sermon.title,
+                    style = Typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                    maxLines = 2
+                )
+                if (youtubeLinkEnabled) {
+                    Spacer(GlanceModifier.width(6.dp))
+                    YoutubeMarker()
+                }
+            }
         }
         // Content and Book Name Section
         LazyColumn(

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/VerseWidgetSmall.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/VerseWidgetSmall.kt
@@ -20,11 +20,13 @@ import androidx.glance.background
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
 import androidx.glance.layout.Column
+import androidx.glance.layout.Row
 import androidx.glance.layout.Spacer
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.height
 import androidx.glance.layout.padding
+import androidx.glance.layout.width
 import androidx.glance.text.Text
 import app.mannadev.meditation.Constants
 import app.mannadev.meditation.R
@@ -39,11 +41,12 @@ class VerseWidgetSmall : GlanceAppWidget(
 ) {
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val sermonRepository = getWidgetDependencies(context).sermonRepository()
+        val youtubeLinkEnabled = getWidgetDependencies(context).getWidgetPrefs().isEnabled()
         provideContent {
             val state by sermonRepository.sermonState.collectAsState()
             val sermon = state.toDisplaySermon(hasAppEverLaunched(context))
             val clickAction = widgetClickAction(sermon.videoUrl, Constants.DEEP_LINK_SUNDAY_SERMON)
-            VerseWidgetSmallContent(sermon, clickAction)
+            VerseWidgetSmallContent(sermon, clickAction, youtubeLinkEnabled)
         }
     }
 
@@ -69,7 +72,7 @@ private object VerseSmallWidgetDimens {
 }
 
 @Composable
-private fun VerseWidgetSmallContent(sermon: Sermon, clickAction: Action) {
+private fun VerseWidgetSmallContent(sermon: Sermon, clickAction: Action, youtubeLinkEnabled: Boolean) {
     Column(
         modifier = GlanceModifier
             .fillMaxSize()
@@ -79,16 +82,26 @@ private fun VerseWidgetSmallContent(sermon: Sermon, clickAction: Action) {
         horizontalAlignment = Alignment.Start,
         verticalAlignment = Alignment.Top
     ) {
-        Text(
+        Row(
             modifier = GlanceModifier
+                .fillMaxWidth()
                 .padding(
                     horizontal = VerseSmallWidgetDimens.horizontalPadding,
                     vertical = VerseSmallWidgetDimens.appBarVerticalPadding
                 ),
-            text = sermon.title,
-            style = Typography.titleMedium,
-            maxLines = 2
-        )
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                modifier = GlanceModifier.defaultWeight(),
+                text = sermon.title,
+                style = Typography.titleMedium,
+                maxLines = 2
+            )
+            if (youtubeLinkEnabled) {
+                Spacer(GlanceModifier.width(6.dp))
+                YoutubeMarker()
+            }
+        }
         Box(
             GlanceModifier
                 .padding(horizontal = VerseSmallWidgetDimens.widgetPadding)

--- a/android/app/src/main/java/app/mannadev/meditation/ui/widget/YoutubeMarker.kt
+++ b/android/app/src/main/java/app/mannadev/meditation/ui/widget/YoutubeMarker.kt
@@ -1,0 +1,18 @@
+package app.mannadev.meditation.ui.widget
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+import androidx.glance.GlanceModifier
+import androidx.glance.Image
+import androidx.glance.ImageProvider
+import androidx.glance.layout.size
+import app.mannadev.meditation.R
+
+@Composable
+fun YoutubeMarker(modifier: GlanceModifier = GlanceModifier) {
+    Image(
+        provider = ImageProvider(R.drawable.ic_youtube_widget),
+        contentDescription = null,
+        modifier = modifier.size(18.dp),
+    )
+}

--- a/android/app/src/main/res/drawable/ic_youtube_widget.xml
+++ b/android/app/src/main/res/drawable/ic_youtube_widget.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="18dp"
+    android:height="18dp"
+    android:viewportWidth="60"
+    android:viewportHeight="60">
+  <path
+      android:pathData="M14,13H46A10,10 0 0 1 56,23V37A10,10 0 0 1 46,47H14A10,10 0 0 1 4,37V23A10,10 0 0 1 14,13Z"
+      android:fillColor="#FF0000"/>
+  <path
+      android:pathData="M23,20L23,40L43,30Z"
+      android:fillColor="#FFFFFF"/>
+</vector>

--- a/docs/superpowers/plans/2026-08-03-issue-203.md
+++ b/docs/superpowers/plans/2026-08-03-issue-203.md
@@ -1,0 +1,158 @@
+# Issue #203: 위젯 유튜브 링크 마커 표시 (Android) — 구현 계획
+
+**Goal:** 설정에서 "유튜브 링크"가 켜져 있을 때, 4개 Android 위젯(주일 말씀 Large/Small, QT Large/Small)의 제목 라인 우측에 유튜브 아이콘 마커를 표시한다. [#167 3안](https://github.com/MannaDevelopers/meditation_blossom_frontend/issues/167#issuecomment-4976440928) 배치 확정.
+
+**Architecture:** 재사용 가능한 `YoutubeMarker` Glance 컴포저블 + 벡터 드로어블 아이콘을 신규 추가하고, 4개 위젯의 `provideGlance()`에서 `getWidgetDependencies(context).getWidgetPrefs().isEnabled()`(동기 함수, 기존 `YoutubeLinkClickAction`이 쓰는 것과 동일 소스)를 읽어 content composable에 `Boolean` 파라미터로 전달한다. 각 제목 `Text`를 `Row`로 감싸 우측에 조건부로 마커를 붙인다.
+
+**Tech Stack:** Kotlin, Jetpack Glance (AppWidget), 기존 DI(`getWidgetDependencies`).
+
+**테스트 정책:** Glance UI는 단위 테스트 대상이 아님. 수동 검증(설정 화면에서 토글 on/off 후 4개 위젯 확인)으로 검증. `WidgetPrefsDataSource.isEnabled()`는 이미 존재하는 동기 함수라 새 로직 없음.
+
+**커밋 정책:** `feature/issue-203` 브랜치, 커밋 메시지 `[ISSUE-203] type: 설명`.
+
+---
+
+## Tasks
+
+### Task 1: 유튜브 마커 아이콘 + 공용 컴포저블 추가
+
+**Files:**
+- Create: `android/app/src/main/res/drawable/ic_youtube_widget.xml`
+- Create: `android/app/src/main/java/app/mannadev/meditation/ui/widget/YoutubeMarker.kt`
+
+`src/assets/icons/YoutubeButton.svg`(빨간 둥근 사각형 + 흰 삼각형, 60×60 viewBox)를 벡터 드로어블로 변환:
+
+```xml
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="18dp"
+    android:height="18dp"
+    android:viewportWidth="60"
+    android:viewportHeight="60">
+  <path
+      android:pathData="M14,13H46A10,10 0 0 1 56,23V37A10,10 0 0 1 46,47H14A10,10 0 0 1 4,37V23A10,10 0 0 1 14,13Z"
+      android:fillColor="#FF0000"/>
+  <path
+      android:pathData="M23,20L23,40L43,30Z"
+      android:fillColor="#FFFFFF"/>
+</vector>
+```
+
+`YoutubeMarker.kt`:
+
+```kotlin
+package app.mannadev.meditation.ui.widget
+
+import androidx.compose.runtime.Composable
+import androidx.glance.GlanceModifier
+import androidx.glance.Image
+import androidx.glance.ImageProvider
+import androidx.compose.ui.unit.dp
+import app.mannadev.meditation.R
+
+@Composable
+fun YoutubeMarker(modifier: GlanceModifier = GlanceModifier) {
+    Image(
+        provider = ImageProvider(R.drawable.ic_youtube_widget),
+        contentDescription = null,
+        modifier = modifier.size(18.dp),
+    )
+}
+```
+
+(`androidx.glance.layout.size` import 필요)
+
+- [ ] 위 두 파일 작성
+- [ ] 커밋: `[ISSUE-203] feat: 위젯 유튜브 마커 아이콘/컴포저블 추가`
+
+---
+
+### Task 2: VerseWidgetLarge.kt — 제목 라인에 마커 적용
+
+**File:** `android/app/src/main/java/app/mannadev/meditation/ui/widget/VerseWidgetLarge.kt`
+
+- `provideGlance()`에서 `val youtubeLinkEnabled = getWidgetDependencies(context).getWidgetPrefs().isEnabled()` 계산 → `VerseWidgetLargeContent(sermon, clickAction, youtubeLinkEnabled)`로 전달
+- `VerseWidgetLargeContent` 시그니처에 `youtubeLinkEnabled: Boolean` 추가
+- 현재:
+  ```kotlin
+  Text(
+      text = sermon.title,
+      style = Typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+      maxLines = 2
+  )
+  ```
+  를 `Row`로 감싸고 우측에 조건부 마커 배치:
+  ```kotlin
+  Row(
+      modifier = GlanceModifier.fillMaxWidth(),
+      verticalAlignment = Alignment.CenterVertically,
+  ) {
+      Text(
+          modifier = GlanceModifier.defaultWeight(),
+          text = sermon.title,
+          style = Typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+          maxLines = 2
+      )
+      if (youtubeLinkEnabled) {
+          Spacer(GlanceModifier.width(6.dp))
+          YoutubeMarker()
+      }
+  }
+  ```
+- import 추가: `androidx.glance.layout.Row`, `androidx.glance.layout.width`
+
+- [ ] 구현
+- [ ] 커밋: `[ISSUE-203] feat: VerseWidgetLarge 유튜브 마커 적용`
+
+---
+
+### Task 3: VerseWidgetSmall.kt — 제목 라인에 마커 적용
+
+**File:** `android/app/src/main/java/app/mannadev/meditation/ui/widget/VerseWidgetSmall.kt`
+
+- Task 2와 동일 패턴: `provideGlance()`에서 `youtubeLinkEnabled` 계산 → `VerseWidgetSmallContent(sermon, clickAction, youtubeLinkEnabled)`
+- 현재 최상위 `Text(text = sermon.title, style = Typography.titleMedium, maxLines = 2)` (padding 있음, 기존 padding modifier는 유지)를 `Row`로 감싸 우측에 조건부 마커
+- 카드형은 제목이 흰 배경(`Color.White`) 위에 직접 있으므로 마커도 그 라인에 자연스럽게 붙음
+
+- [ ] 구현
+- [ ] 커밋: `[ISSUE-203] feat: VerseWidgetSmall 유튜브 마커 적용`
+
+---
+
+### Task 4: QtWidgetLarge.kt — 제목 라인에 마커 적용
+
+**File:** `android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetLarge.kt`
+
+- `provideGlance()`에서 `youtubeLinkEnabled` 계산 → `QtWidgetLargeContent(uiModel, clickAction, youtubeLinkEnabled)`
+- 현재 제목은 `dateLabel` 아래 별도 `Text(text = ui.title, ...)`. 이 `Text`만 `Row`로 감싼다 (dateLabel 줄은 그대로 유지)
+
+- [ ] 구현
+- [ ] 커밋: `[ISSUE-203] feat: QtWidgetLarge 유튜브 마커 적용`
+
+---
+
+### Task 5: QtWidgetSmall.kt — 제목 라인에 마커 적용
+
+**File:** `android/app/src/main/java/app/mannadev/meditation/ui/widget/QtWidgetSmall.kt`
+
+- Task 2와 동일 패턴 적용 (`QtWidgetSmallContent`에 `youtubeLinkEnabled: Boolean` 파라미터 추가)
+
+- [ ] 구현
+- [ ] 커밋: `[ISSUE-203] feat: QtWidgetSmall 유튜브 마커 적용`
+
+---
+
+### Task 6: 빌드 확인 + 수동 검증 시나리오 기록
+
+- [ ] `cd android && ./gradlew :app:compileDebugKotlin` (또는 동등 명령)로 컴파일 확인
+- [ ] PR 본문에 아래 수동 검증 체크리스트 포함 (실제 기기/에뮬레이터 실행은 CI 환경상 生략 가능하므로 리뷰어가 직접 확인하도록 안내):
+  - 설정 > 위젯 설정에서 "유튜브 링크"로 전환 → 4개 위젯 모두 제목 우측에 마커 표시
+  - "메인 앱 화면(기본)"으로 전환 → 마커 사라짐
+  - 위젯 클릭 시 정상적으로 유튜브 이동 (기존 `YoutubeLinkClickAction` 로직 미변경 확인)
+
+---
+
+## Self-Review 결과
+
+- **이슈 커버리지**: #203의 대상 파일 4개, 표시 조건, 아이콘 에셋, 배치(3안) 모두 task에 매핑됨
+- **기존 패턴 재사용**: `isEnabled()`는 이미 존재하는 동기 함수(신규 로직 없음), 클릭 라우팅(`YoutubeLinkClickAction`)은 변경하지 않음
+- **외부 의존 없음**: 신규 라이브러리 불필요, 기존 Glance API만 사용


### PR DESCRIPTION
## 이슈
Closes #203

## 요약
설정 > 위젯 설정에서 "유튜브 링크"가 켜져 있으면, 4개 Android 위젯(주일 말씀 Large/Small, 매일 만나 QT Large/Small)의 제목 라인 우측에 유튜브 아이콘 마커를 표시한다. 배치는 [#167 3안](https://github.com/MannaDevelopers/meditation_blossom_frontend/issues/167#issuecomment-4976440928)(제목과 같은 라인, 우측)로 확정된 것을 반영.

## 변경점
- 신규: `ic_youtube_widget.xml` (RN `YoutubeButton.svg` 기반 벡터 드로어블), `YoutubeMarker.kt` (재사용 가능한 Glance 컴포저블)
- `VerseWidgetLarge/Small.kt`, `QtWidgetLarge/Small.kt`: `provideGlance()`에서 `getWidgetDependencies(context).getWidgetPrefs().isEnabled()`(기존 `YoutubeLinkClickAction`이 클릭 라우팅에 쓰는 것과 동일 소스)를 읽어 content composable에 전달, 제목 `Text`를 `Row`로 감싸 우측에 조건부 마커 배치
- 클릭 라우팅 로직(`YoutubeLinkClickAction`)은 변경 없음

## 테스트
- [x] `:app:compileDebugKotlin` 빌드 성공 확인
- [ ] (리뷰어 수동 확인) 설정 > 위젯 설정에서 "유튜브 링크"로 전환 → 4개 위젯 모두 마커 표시
- [ ] (리뷰어 수동 확인) "메인 앱 화면(기본)"으로 전환 → 마커 사라짐
- [ ] (리뷰어 수동 확인) 위젯 클릭 시 정상적으로 유튜브 이동

🤖 Generated with [Claude Code](https://claude.com/claude-code)