### PR TITLE
[ISSUE-203] 유튜브 마커 아이콘 빨간 배경 세로 여백 축소

### DIFF
--- a/android/app/src/main/res/drawable/ic_youtube_widget.xml
+++ b/android/app/src/main/res/drawable/ic_youtube_widget.xml
@@ -4,7 +4,7 @@
     android:viewportWidth="60"
     android:viewportHeight="60">
   <path
-      android:pathData="M14,13H46A10,10 0 0 1 56,23V37A10,10 0 0 1 46,47H14A10,10 0 0 1 4,37V23A10,10 0 0 1 14,13Z"
+      android:pathData="M14,4H46A10,10 0 0 1 56,14V46A10,10 0 0 1 46,56H14A10,10 0 0 1 4,46V14A10,10 0 0 1 14,4Z"
       android:fillColor="#FF0000"/>
   <path
       android:pathData="M23,20L23,40L43,30Z"


### PR DESCRIPTION
## 배경
#203 머지 후 실기기 확인 결과, 유튜브 마커 아이콘의 빨간 배경 위아래 여백이 좌우 대비 너무 두꺼워 보임.

## 변경점
`ic_youtube_widget.xml`의 빨간 둥근 사각형을 y=13~47(높이 34) → y=4~56(높이 52)로 키워서 좌우 여백(4px)과 상하 여백을 동일하게 맞춤. 흰 삼각형(`M23,20L23,40L43,30Z`)은 변경 없음 — 새 사각형 안에서도 그대로 세로 중앙(y=30)에 위치.

🤖 Generated with [Claude Code](https://claude.com/claude-code)