### PR TITLE
[ISSUE-204] 위젯 유튜브 링크 마커 표시 (iOS)

### DIFF
--- a/docs/superpowers/plans/2026-08-05-issue-204.md
+++ b/docs/superpowers/plans/2026-08-05-issue-204.md
@@ -1,0 +1,149 @@
+# Issue #204: 위젯 유튜브 링크 마커 표시 (iOS) — 구현 계획
+
+**Goal:** 설정에서 "유튜브 링크"가 켜져 있을 때, iOS 위젯 6곳(Sermon Large/Medium, QT 말씀 Large/Medium, QT 묵상질문 Large/Medium)의 제목 라인 우측에 유튜브 아이콘 마커를 표시한다. [#167 3안](https://github.com/MannaDevelopers/meditation_blossom_frontend/issues/167#issuecomment-4976440928) 배치 확정 (Android #203과 동일 배치).
+
+**⚠️ 빌드 검증 불가**: 이 작업 환경은 Windows라 Xcode가 없다. Swift 코드는 기존 패턴을 최대한 따라 작성하지만 컴파일 확인은 못 한다. PR 테스트 체크리스트는 전부 리뷰어(Mac 환경)용으로 남긴다.
+
+**Architecture:** 공유 `YoutubeMarkerView.swift`(SwiftUI로 Android 아이콘과 동일한 모양 — 빨간 둥근 사각형 + 흰 삼각형 — 을 코드로 그림. 이미지 에셋 추가 불필요) + `entry.youtubeLinkEnabled`는 이미 `SimpleEntry`/`QTEntry` 양쪽에 존재하므로 새 데이터 배선 없이 뷰 코드만 수정한다.
+
+**Tech Stack:** SwiftUI, WidgetKit.
+
+**테스트 정책:** 컴파일/UI 테스트 불가 환경. PR에 리뷰어용 수동 검증 체크리스트 명시.
+
+**커밋 정책:** `feature/issue-204` 브랜치, 커밋 메시지 `[ISSUE-204] type: 설명`.
+
+---
+
+## Tasks
+
+### Task 1: 공유 유튜브 마커 뷰 추가
+
+**File:** Create `ios/MeditationBlossomWidget/YoutubeMarkerView.swift`
+
+Android `ic_youtube_widget.xml`(빨간 둥근 사각형 + 흰 삼각형, PR #206에서 세로 여백 축소된 최신 버전 기준)과 톤을 맞춘 SwiftUI 뷰. 이미지 에셋을 새로 추가하는 대신 `Shape`으로 직접 그려서 에셋 카탈로그 작업(Xcode 필요) 없이 구현한다.
+
+```swift
+import SwiftUI
+
+struct YoutubeMarkerView: View {
+  var body: some View {
+    ZStack {
+      RoundedRectangle(cornerRadius: 3)
+        .fill(Color(red: 1, green: 0, blue: 0))
+      YoutubeTriangle()
+        .fill(Color.white)
+        .frame(width: 6, height: 7)
+    }
+    .frame(width: 16, height: 16)
+  }
+}
+
+private struct YoutubeTriangle: Shape {
+  func path(in rect: CGRect) -> Path {
+    var path = Path()
+    path.move(to: CGPoint(x: rect.minX, y: rect.minY))
+    path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+    path.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
+    path.closeSubpath()
+    return path
+  }
+}
+```
+
+- [ ] 파일 작성
+- [ ] 커밋: `[ISSUE-204] feat: 위젯 유튜브 마커 SwiftUI 뷰 추가`
+
+---
+
+### Task 2: MeditationBlossomWidget.swift (Sermon 위젯) 적용
+
+**File:** `ios/MeditationBlossomWidget/MeditationBlossomWidget.swift`
+
+**systemLarge** (194~213행): 현재 `Text(entry.title)` 단독 → `HStack`으로 감싸 우측에 조건부 마커:
+```swift
+HStack(alignment: .top) {
+  Text(entry.title)
+    .font(.system(size: 18, weight: .bold))
+    .foregroundColor(primaryText)
+    .lineLimit(2)
+  Spacer(minLength: 4)
+  if entry.youtubeLinkEnabled {
+    YoutubeMarkerView()
+  }
+}
+```
+
+**systemMedium** (243~255행): 기존 `HStack(alignment: .firstTextBaseline) { Text(title); if !verse.isEmpty { Spacer; Text(verse) } }`의 마지막에 조건부 마커 추가 (verse 유무와 무관하게 title 라인 맨 오른쪽 끝에 위치):
+```swift
+HStack(alignment: .firstTextBaseline) {
+  Text(entry.title)...
+  if !entry.verse.trimmingCharacters(in: .whitespaces).isEmpty {
+    Spacer(minLength: 4)
+    Text(entry.verse)...
+  }
+  if entry.youtubeLinkEnabled {
+    Spacer(minLength: 4)
+    YoutubeMarkerView()
+  }
+}
+```
+
+- [ ] 구현
+- [ ] 커밋: `[ISSUE-204] feat: MeditationBlossomWidget 유튜브 마커 적용`
+
+---
+
+### Task 3: DailyMannaWidget.swift — QT 말씀 위젯(DailyMannaContentEntryView) 적용
+
+**File:** `ios/MeditationBlossomWidget/DailyMannaWidget.swift`
+
+**largeContent** (224~228행): `Text(entry.mergedTitle)` 단독 → Task 2 Large와 동일 패턴으로 `HStack` 적용.
+
+**mediumContent** (258~270행): 기존 `HStack { Text(mergedTitle); if !reference.isEmpty { Spacer; Text(reference) } }` 끝에 Task 2 Medium과 동일하게 조건부 마커 추가.
+
+- [ ] 구현
+- [ ] 커밋: `[ISSUE-204] feat: DailyMannaContentWidget 유튜브 마커 적용`
+
+---
+
+### Task 4: DailyMannaWidget.swift — QT 묵상질문 위젯(DailyMannaMeditationEntryView) 적용
+
+**File:** `ios/MeditationBlossomWidget/DailyMannaWidget.swift`
+
+**largeContent** (342~346행): `Text(entry.mergedTitle)` 단독 → Task 2 Large와 동일 패턴.
+
+**mediumContent** (390~397행): 이 케이스는 다른 곳과 구조가 다름 — `HStack { SectionHeader("묵상 질문"); Spacer; Text(mergedTitle) }`으로 title이 이미 맨 오른쪽. title 뒤에 마커 추가:
+```swift
+HStack(alignment: .center) {
+  SectionHeader(title: "묵상 질문")
+  Spacer(minLength: 6)
+  Text(entry.mergedTitle)...
+  if entry.youtubeLinkEnabled {
+    Spacer(minLength: 4)
+    YoutubeMarkerView()
+  }
+}
+```
+
+- [ ] 구현
+- [ ] 커밋: `[ISSUE-204] feat: DailyMannaMeditationWidget 유튜브 마커 적용`
+
+---
+
+### Task 5: PR 테스트 체크리스트 작성 (리뷰어용)
+
+빌드 검증이 불가능하므로 PR 본문에 아래를 명시:
+
+- [ ] Xcode에서 빌드/문법 오류 없이 컴파일되는지 확인
+- [ ] 설정 > 위젯 설정에서 "유튜브 링크"로 전환 → 6개 위젯(Sermon L/M, QT 말씀 L/M, QT 묵상질문 L/M) 모두 마커 표시 확인
+- [ ] "메인 앱 화면(기본)"으로 전환 → 마커 사라짐 확인
+- [ ] 위젯 갤러리 미리보기에도 반영되는지 확인 ([#169](https://github.com/MannaDevelopers/meditation_blossom_frontend/issues/169)에 따르면 iOS는 `getSnapshot`이 App Group을 실제로 읽으므로 자동 반영될 것으로 예상)
+- [ ] 위젯 클릭 시 정상적으로 유튜브 이동 (targetURL 로직은 변경하지 않음)
+
+---
+
+## Self-Review 결과
+
+- **이슈 커버리지**: #204에 명시된 배치·표시 조건·구현 메모 모두 반영. 실제로는 이슈가 언급한 "2개 파일"이 위젯 6곳(1개 파일에 QT 위젯 2종 존재)임을 확인하고 전부 포함시킴
+- **기존 패턴 재사용**: `youtubeLinkEnabled`는 이미 두 Entry 모두에 존재 — 새 데이터 배선 없음. 아이콘은 이미지 에셋 대신 SwiftUI Shape로 그려 Xcode 에셋 카탈로그 작업 불필요
+- **리스크**: 빌드 미검증. PR에 명확히 표시하고 리뷰어 수동 확인 항목으로 전가

--- a/ios/MeditationBlossomWidget/DailyMannaWidget.swift
+++ b/ios/MeditationBlossomWidget/DailyMannaWidget.swift
@@ -221,7 +221,7 @@ struct DailyMannaContentEntryView: View {
           .foregroundColor(WT.secondaryText)
       }
 
-      HStack(alignment: .top) {
+      HStack(alignment: .center) {
         Text(entry.mergedTitle)
           .font(.system(size: WT.titleFontSizeLarge, weight: .bold))
           .foregroundColor(WT.primaryText)
@@ -275,7 +275,11 @@ struct DailyMannaContentEntryView: View {
         }
         if entry.youtubeLinkEnabled {
           Spacer(minLength: 4)
+          // 행 전체가 firstTextBaseline로 정렬되는데 마커는 텍스트가 아니라
+          // 기준선이 없으므로, 자신의 세로 중앙을 기준선으로 취급하게 해서
+          // 제목/참조 텍스트 중앙 높이에 맞춘다.
           YoutubeMarkerView()
+            .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] }
         }
       }
       .padding(.horizontal, WT.outerPad)
@@ -349,7 +353,7 @@ struct DailyMannaMeditationEntryView: View {
           .foregroundColor(WT.secondaryText)
       }
 
-      HStack(alignment: .top) {
+      HStack(alignment: .center) {
         Text(entry.mergedTitle)
           .font(.system(size: WT.titleFontSizeLarge, weight: .bold))
           .foregroundColor(WT.primaryText)

--- a/ios/MeditationBlossomWidget/DailyMannaWidget.swift
+++ b/ios/MeditationBlossomWidget/DailyMannaWidget.swift
@@ -280,7 +280,7 @@ struct DailyMannaContentEntryView: View {
           // firstTextBaseline 정렬 행에서 텍스트가 아닌 마커는 살짝 아래로
           // 치우쳐 보여서(폰트 메트릭 특성상), 수동으로 위로 보정한다.
           YoutubeMarkerView()
-            .offset(y: -1.5)
+            .offset(y: -0.5)
         }
       }
       .padding(.horizontal, WT.outerPad)

--- a/ios/MeditationBlossomWidget/DailyMannaWidget.swift
+++ b/ios/MeditationBlossomWidget/DailyMannaWidget.swift
@@ -228,7 +228,9 @@ struct DailyMannaContentEntryView: View {
           .lineLimit(2)
         Spacer(minLength: 4)
         if entry.youtubeLinkEnabled {
+          // .center 정렬이어도 폰트 메트릭 특성상 살짝 아래로 치우쳐 보여서 위로 보정.
           YoutubeMarkerView()
+            .offset(y: -1.5)
         }
       }
       .padding(.top, entry.dateLabel.isEmpty ? 0 : WT.innerGap)
@@ -275,11 +277,10 @@ struct DailyMannaContentEntryView: View {
         }
         if entry.youtubeLinkEnabled {
           Spacer(minLength: 4)
-          // 행 전체가 firstTextBaseline로 정렬되는데 마커는 텍스트가 아니라
-          // 기준선이 없으므로, 자신의 세로 중앙을 기준선으로 취급하게 해서
-          // 제목/참조 텍스트 중앙 높이에 맞춘다.
+          // firstTextBaseline 정렬 행에서 텍스트가 아닌 마커는 살짝 아래로
+          // 치우쳐 보여서(폰트 메트릭 특성상), 수동으로 위로 보정한다.
           YoutubeMarkerView()
-            .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] }
+            .offset(y: -1.5)
         }
       }
       .padding(.horizontal, WT.outerPad)
@@ -360,7 +361,9 @@ struct DailyMannaMeditationEntryView: View {
           .lineLimit(2)
         Spacer(minLength: 4)
         if entry.youtubeLinkEnabled {
+          // .center 정렬이어도 폰트 메트릭 특성상 살짝 아래로 치우쳐 보여서 위로 보정.
           YoutubeMarkerView()
+            .offset(y: -1.5)
         }
       }
       .padding(.top, entry.dateLabel.isEmpty ? 0 : WT.innerGap)

--- a/ios/MeditationBlossomWidget/DailyMannaWidget.swift
+++ b/ios/MeditationBlossomWidget/DailyMannaWidget.swift
@@ -221,11 +221,17 @@ struct DailyMannaContentEntryView: View {
           .foregroundColor(WT.secondaryText)
       }
 
-      Text(entry.mergedTitle)
-        .font(.system(size: WT.titleFontSizeLarge, weight: .bold))
-        .foregroundColor(WT.primaryText)
-        .lineLimit(2)
-        .padding(.top, entry.dateLabel.isEmpty ? 0 : WT.innerGap)
+      HStack(alignment: .top) {
+        Text(entry.mergedTitle)
+          .font(.system(size: WT.titleFontSizeLarge, weight: .bold))
+          .foregroundColor(WT.primaryText)
+          .lineLimit(2)
+        Spacer(minLength: 4)
+        if entry.youtubeLinkEnabled {
+          YoutubeMarkerView()
+        }
+      }
+      .padding(.top, entry.dateLabel.isEmpty ? 0 : WT.innerGap)
 
       if !entry.reference.isEmpty {
         Text(entry.reference)
@@ -266,6 +272,10 @@ struct DailyMannaContentEntryView: View {
             .font(.system(size: WT.refFontSize, weight: .semibold))
             .foregroundColor(WT.accentText)
             .lineLimit(1)
+        }
+        if entry.youtubeLinkEnabled {
+          Spacer(minLength: 4)
+          YoutubeMarkerView()
         }
       }
       .padding(.horizontal, WT.outerPad)
@@ -339,11 +349,17 @@ struct DailyMannaMeditationEntryView: View {
           .foregroundColor(WT.secondaryText)
       }
 
-      Text(entry.mergedTitle)
-        .font(.system(size: WT.titleFontSizeLarge, weight: .bold))
-        .foregroundColor(WT.primaryText)
-        .lineLimit(2)
-        .padding(.top, entry.dateLabel.isEmpty ? 0 : WT.innerGap)
+      HStack(alignment: .top) {
+        Text(entry.mergedTitle)
+          .font(.system(size: WT.titleFontSizeLarge, weight: .bold))
+          .foregroundColor(WT.primaryText)
+          .lineLimit(2)
+        Spacer(minLength: 4)
+        if entry.youtubeLinkEnabled {
+          YoutubeMarkerView()
+        }
+      }
+      .padding(.top, entry.dateLabel.isEmpty ? 0 : WT.innerGap)
 
       SectionHeader(title: "묵상 질문")
         .padding(.top, WT.sectionGap)
@@ -394,6 +410,10 @@ struct DailyMannaMeditationEntryView: View {
           .font(.system(size: 12, weight: .bold))
           .foregroundColor(WT.primaryText)
           .lineLimit(1)
+        if entry.youtubeLinkEnabled {
+          Spacer(minLength: 4)
+          YoutubeMarkerView()
+        }
       }
       .padding(.horizontal, WT.outerPad)
       .padding(.top, WT.outerPad)

--- a/ios/MeditationBlossomWidget/DailyMannaWidget.swift
+++ b/ios/MeditationBlossomWidget/DailyMannaWidget.swift
@@ -263,7 +263,8 @@ struct DailyMannaContentEntryView: View {
   // Medium (364 × 170)
   private var mediumContent: some View {
     VStack(alignment: .leading, spacing: WT.innerGap) {
-      HStack(alignment: .firstTextBaseline) {
+      // QT 묵상질문 위젯과 동일하게 .center 정렬로 마커를 배치한다.
+      HStack(alignment: .center) {
         Text(entry.mergedTitle)
           .font(.system(size: WT.titleFontSizeMedium, weight: .bold))
           .foregroundColor(WT.primaryText)
@@ -277,10 +278,7 @@ struct DailyMannaContentEntryView: View {
         }
         if entry.youtubeLinkEnabled {
           Spacer(minLength: 4)
-          // firstTextBaseline 정렬 행에서 텍스트가 아닌 마커는 살짝 아래로
-          // 치우쳐 보여서(폰트 메트릭 특성상), 수동으로 위로 보정한다.
           YoutubeMarkerView()
-            .offset(y: -0.5)
         }
       }
       .padding(.horizontal, WT.outerPad)

--- a/ios/MeditationBlossomWidget/MeditationBlossomWidget.swift
+++ b/ios/MeditationBlossomWidget/MeditationBlossomWidget.swift
@@ -245,8 +245,8 @@ struct MeditationBlossomWidgetEntryView : View {
             .aspectRatio(contentMode: .fill)
 
           VStack(alignment: .leading, spacing: 6) {
-            // 제목 + 참조 행
-            HStack(alignment: .firstTextBaseline) {
+            // 제목 + 참조 행 — QT 묵상질문 위젯과 동일하게 .center 정렬로 마커를 배치한다.
+            HStack(alignment: .center) {
               Text(entry.title)
                 .font(.system(size: 14, weight: .bold))
                 .foregroundColor(primaryText)
@@ -260,10 +260,7 @@ struct MeditationBlossomWidgetEntryView : View {
               }
               if entry.youtubeLinkEnabled {
                 Spacer(minLength: 4)
-                // firstTextBaseline 정렬 행에서 텍스트가 아닌 마커는 살짝 아래로
-                // 치우쳐 보여서(폰트 메트릭 특성상), 수동으로 위로 보정한다.
                 YoutubeMarkerView()
-                  .offset(y: -0.5)
               }
             }
             .padding(.horizontal, 18)

--- a/ios/MeditationBlossomWidget/MeditationBlossomWidget.swift
+++ b/ios/MeditationBlossomWidget/MeditationBlossomWidget.swift
@@ -260,11 +260,10 @@ struct MeditationBlossomWidgetEntryView : View {
               }
               if entry.youtubeLinkEnabled {
                 Spacer(minLength: 4)
-                // 행 전체가 firstTextBaseline로 정렬되는데 마커는 텍스트가 아니라
-                // 기준선이 없으므로, 자신의 세로 중앙을 기준선으로 취급하게 해서
-                // 제목/참조 텍스트 중앙 높이에 맞춘다.
+                // firstTextBaseline 정렬 행에서 텍스트가 아닌 마커는 살짝 아래로
+                // 치우쳐 보여서(폰트 메트릭 특성상), 수동으로 위로 보정한다.
                 YoutubeMarkerView()
-                  .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] }
+                  .offset(y: -1.5)
               }
             }
             .padding(.horizontal, 18)

--- a/ios/MeditationBlossomWidget/MeditationBlossomWidget.swift
+++ b/ios/MeditationBlossomWidget/MeditationBlossomWidget.swift
@@ -199,10 +199,16 @@ struct MeditationBlossomWidgetEntryView : View {
 
           VStack(alignment: .leading, spacing: 0) {
             // 제목
-            Text(entry.title)
-              .font(.system(size: 18, weight: .bold))
-              .foregroundColor(primaryText)
-              .lineLimit(2)
+            HStack(alignment: .top) {
+              Text(entry.title)
+                .font(.system(size: 18, weight: .bold))
+                .foregroundColor(primaryText)
+                .lineLimit(2)
+              Spacer(minLength: 4)
+              if entry.youtubeLinkEnabled {
+                YoutubeMarkerView()
+              }
+            }
 
             // 본문 참조
             if !entry.verse.trimmingCharacters(in: .whitespaces).isEmpty {
@@ -251,6 +257,10 @@ struct MeditationBlossomWidgetEntryView : View {
                   .font(.system(size: 12, weight: .semibold))
                   .foregroundColor(accentText)
                   .lineLimit(1)
+              }
+              if entry.youtubeLinkEnabled {
+                Spacer(minLength: 4)
+                YoutubeMarkerView()
               }
             }
             .padding(.horizontal, 18)

--- a/ios/MeditationBlossomWidget/MeditationBlossomWidget.swift
+++ b/ios/MeditationBlossomWidget/MeditationBlossomWidget.swift
@@ -263,7 +263,7 @@ struct MeditationBlossomWidgetEntryView : View {
                 // firstTextBaseline 정렬 행에서 텍스트가 아닌 마커는 살짝 아래로
                 // 치우쳐 보여서(폰트 메트릭 특성상), 수동으로 위로 보정한다.
                 YoutubeMarkerView()
-                  .offset(y: -1.5)
+                  .offset(y: -0.5)
               }
             }
             .padding(.horizontal, 18)

--- a/ios/MeditationBlossomWidget/MeditationBlossomWidget.swift
+++ b/ios/MeditationBlossomWidget/MeditationBlossomWidget.swift
@@ -198,8 +198,8 @@ struct MeditationBlossomWidgetEntryView : View {
             .aspectRatio(contentMode: .fill)
 
           VStack(alignment: .leading, spacing: 0) {
-            // 제목
-            HStack(alignment: .top) {
+            // 제목 (2줄까지 가능 — 마커는 항상 전체 제목 높이의 중앙에 위치)
+            HStack(alignment: .center) {
               Text(entry.title)
                 .font(.system(size: 18, weight: .bold))
                 .foregroundColor(primaryText)
@@ -260,7 +260,11 @@ struct MeditationBlossomWidgetEntryView : View {
               }
               if entry.youtubeLinkEnabled {
                 Spacer(minLength: 4)
+                // 행 전체가 firstTextBaseline로 정렬되는데 마커는 텍스트가 아니라
+                // 기준선이 없으므로, 자신의 세로 중앙을 기준선으로 취급하게 해서
+                // 제목/참조 텍스트 중앙 높이에 맞춘다.
                 YoutubeMarkerView()
+                  .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] }
               }
             }
             .padding(.horizontal, 18)

--- a/ios/MeditationBlossomWidget/YoutubeMarkerView.swift
+++ b/ios/MeditationBlossomWidget/YoutubeMarkerView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct YoutubeMarkerView: View {
+  var body: some View {
+    ZStack {
+      RoundedRectangle(cornerRadius: 3)
+        .fill(Color(red: 1, green: 0, blue: 0))
+      YoutubeTriangle()
+        .fill(Color.white)
+        .frame(width: 6, height: 7)
+    }
+    .frame(width: 16, height: 16)
+  }
+}
+
+private struct YoutubeTriangle: Shape {
+  func path(in rect: CGRect) -> Path {
+    var path = Path()
+    path.move(to: CGPoint(x: rect.minX, y: rect.minY))
+    path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+    path.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
+    path.closeSubpath()
+    return path
+  }
+}

--- a/ios/MeditationBlossomWidget/YoutubeMarkerView.swift
+++ b/ios/MeditationBlossomWidget/YoutubeMarkerView.swift
@@ -1,15 +1,18 @@
 import SwiftUI
 
 struct YoutubeMarkerView: View {
+  // Android ic_youtube_widget.xml(60x60 viewport, 빨간 사각형 52x43)과 동일한
+  // 가로:세로 비율을 유지하도록 크기를 맞춤 (정사각형이 아니라 가로가 더 넓은 사각형).
   var body: some View {
     ZStack {
       RoundedRectangle(cornerRadius: 3)
         .fill(Color(red: 1, green: 0, blue: 0))
+        .frame(width: 16, height: 13)
       YoutubeTriangle()
         .fill(Color.white)
-        .frame(width: 6, height: 7)
+        .frame(width: 6, height: 6)
     }
-    .frame(width: 16, height: 16)
+    .frame(width: 18, height: 18)
   }
 }
 

--- a/ios/meditation_blossom.xcodeproj/project.pbxproj
+++ b/ios/meditation_blossom.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		354EC78F2E13D06F00E2A018 /* WidgetUpdateModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 354EC78D2E13D06F00E2A018 /* WidgetUpdateModule.swift */; };
 		35570001BBBB0001BBBBBBBB /* QT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35570000BBBB0001BBBBBBBB /* QT.swift */; };
 		35570003BBBB0001BBBBBBBB /* DailyMannaWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35570002BBBB0001BBBBBBBB /* DailyMannaWidget.swift */; };
+		35580001CAFE0001CAFECAFE /* YoutubeMarkerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35580000CAFE0001CAFECAFE /* YoutubeMarkerView.swift */; };
 		3578DB062DEA121C0046B6A0 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3578DB052DEA121C0046B6A0 /* WidgetKit.framework */; };
 		3578DB082DEA121C0046B6A0 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3578DB072DEA121C0046B6A0 /* SwiftUI.framework */; };
 		3578DB192DEA121D0046B6A0 /* MeditationBlossomWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 3578DB042DEA121C0046B6A0 /* MeditationBlossomWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -109,6 +110,7 @@
 		354EC78D2E13D06F00E2A018 /* WidgetUpdateModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetUpdateModule.swift; sourceTree = "<group>"; };
 		35570000BBBB0001BBBBBBBB /* QT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QT.swift; sourceTree = "<group>"; };
 		35570002BBBB0001BBBBBBBB /* DailyMannaWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyMannaWidget.swift; sourceTree = "<group>"; };
+		35580000CAFE0001CAFECAFE /* YoutubeMarkerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YoutubeMarkerView.swift; sourceTree = "<group>"; };
 		3578DB042DEA121C0046B6A0 /* MeditationBlossomWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = MeditationBlossomWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		3578DB052DEA121C0046B6A0 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		3578DB072DEA121C0046B6A0 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
@@ -270,6 +272,7 @@
 				3595A3072DEBF76F006716D8 /* MeditationBlossomWidgetBundle.swift */,
 				3595A3092DEBF76F006716D8 /* MeditationBlossomWidgetLiveActivity.swift */,
 				35570002BBBB0001BBBBBBBB /* DailyMannaWidget.swift */,
+				35580000CAFE0001CAFECAFE /* YoutubeMarkerView.swift */,
 			);
 			path = MeditationBlossomWidget;
 			sourceTree = "<group>";
@@ -791,6 +794,7 @@
 				35B6CFCF2E01AC0E004A13DD /* Sermon.swift in Sources */,
 				35570001BBBB0001BBBBBBBB /* QT.swift in Sources */,
 				35570003BBBB0001BBBBBBBB /* DailyMannaWidget.swift in Sources */,
+				35580001CAFE0001CAFECAFE /* YoutubeMarkerView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## 이슈
Closes #204

## 요약
설정 > 위젯 설정에서 "유튜브 링크"가 켜져 있으면, iOS 위젯 6곳(Sermon Large/Medium, QT 말씀 Large/Medium, QT 묵상질문 Large/Medium)의 제목 라인 우측에 유튜브 아이콘 마커를 표시한다. 배치는 [#167 3안](https://github.com/MannaDevelopers/meditation_blossom_frontend/issues/167#issuecomment-4976440928)(Android #203과 동일)로 확정된 것을 반영.

## ⚠️ 빌드 미검증
이 PR은 Windows 환경에서 작성되어 Xcode로 컴파일 확인을 하지 못했습니다. Mac에서 열어서 빌드 확인 후 머지해주세요.

## 변경점
- 신규: `YoutubeMarkerView.swift` — SwiftUI `Shape`으로 Android 아이콘(PR #206 기준, 빨간 둥근 사각형 + 흰 삼각형)과 톤을 맞춰 그림. 이미지 에셋 추가 없이 구현
- `project.pbxproj`: 새 Swift 파일을 `MeditationBlossomWidgetExtension` 타겟에 등록 (PBXFileReference/PBXBuildFile/그룹/Sources 빌드 페이즈)
- `MeditationBlossomWidget.swift`: Sermon 위젯 Large/Medium 제목 라인에 마커 적용
- `DailyMannaWidget.swift`: QT 말씀 위젯, QT 묵상질문 위젯 각각 Large/Medium 제목 라인에 마커 적용 (묵상질문 Medium은 제목이 이미 줄 우측 끝에 있어 다른 곳과 배치 패턴이 다름)
- `entry.youtubeLinkEnabled`는 `SimpleEntry`/`QTEntry` 양쪽에 이미 존재하던 필드라 새 데이터 배선 없음

## 테스트
- [ ] Xcode에서 빌드/문법 오류 없이 컴파일되는지 확인
- [ ] 설정 > 위젯 설정에서 "유튜브 링크"로 전환 → 6개 위젯 모두 마커 표시 확인
- [ ] "메인 앱 화면(기본)"으로 전환 → 마커 사라짐 확인
- [ ] 위젯 갤러리 미리보기에도 반영되는지 확인 ([#169](https://github.com/MannaDevelopers/meditation_blossom_frontend/issues/169) 참고, `getSnapshot`이 App Group을 읽으므로 자동 반영 예상)
- [ ] 위젯 클릭 시 정상적으로 유튜브 이동 (targetURL 로직 미변경)

🤖 Generated with [Claude Code](https://claude.com/claude-code)