### PR TITLE
[ISSUE-203] 유튜브 마커 아이콘 여백 중간값 조정

### DIFF
--- a/android/app/src/main/res/drawable/ic_youtube_widget.xml
+++ b/android/app/src/main/res/drawable/ic_youtube_widget.xml
@@ -4,7 +4,7 @@
     android:viewportWidth="60"
     android:viewportHeight="60">
   <path
-      android:pathData="M14,4H46A10,10 0 0 1 56,14V46A10,10 0 0 1 46,56H14A10,10 0 0 1 4,46V14A10,10 0 0 1 14,4Z"
+      android:pathData="M18.5,8.5H41.5A10,10 0 0 1 51.5,18.5V41.5A10,10 0 0 1 41.5,51.5H18.5A10,10 0 0 1 8.5,41.5V18.5A10,10 0 0 1 18.5,8.5Z"
       android:fillColor="#FF0000"/>
   <path
       android:pathData="M23,20L23,40L43,30Z"


### PR DESCRIPTION
## 배경
PR #206(여백4)까지 적용해보니 실기기에서 빨간 영역이 너무 커 보임. PR #205(여백13, before) ↔ PR #206(여백4, after) 사이 정확한 중간값으로 재조정.

## 변경점
`ic_youtube_widget.xml`의 빨간 사각형 여백을 8.5(=(13+4)/2)로, 모서리 반지름은 10 유지. 흰 삼각형 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)