### PR TITLE
[ISSUE-203] 유튜브 마커 아이콘 가로 여백 복원

### DIFF
--- a/android/app/src/main/res/drawable/ic_youtube_widget.xml
+++ b/android/app/src/main/res/drawable/ic_youtube_widget.xml
@@ -4,7 +4,7 @@
     android:viewportWidth="60"
     android:viewportHeight="60">
   <path
-      android:pathData="M18.5,8.5H41.5A10,10 0 0 1 51.5,18.5V41.5A10,10 0 0 1 41.5,51.5H18.5A10,10 0 0 1 8.5,41.5V18.5A10,10 0 0 1 18.5,8.5Z"
+      android:pathData="M14,8.5H46A10,10 0 0 1 56,18.5V41.5A10,10 0 0 1 46,51.5H14A10,10 0 0 1 4,41.5V18.5A10,10 0 0 1 14,8.5Z"
       android:fillColor="#FF0000"/>
   <path
       android:pathData="M23,20L23,40L43,30Z"


### PR DESCRIPTION
## 배경
PR #208에서 중간값을 계산할 때 가로/세로 여백을 동일하게(8.5) 맞췄는데, 원래 두 기준 커밋(#205, #206) 모두 가로 여백은 4로 고정이었고 세로만 달랐음. 실기기 미리보기 확인 결과 가로가 좁아진 게 확인되어 가로만 원래값(4)으로 복원.

## 변경점
`ic_youtube_widget.xml` 빨간 사각형: 가로 여백 8.5 → 4 복원, 세로 여백은 8.5(PR #208에서 정한 중간값) 유지. 흰 삼각형 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)