### PR TITLE
[ISSUE-211] 위젯 디자인 스키마/프리셋 정의

### DIFF
--- a/__tests__/WidgetDesign.test.ts
+++ b/__tests__/WidgetDesign.test.ts
@@ -1,0 +1,35 @@
+import { DEFAULT_WIDGET_DESIGN } from '../src/types/WidgetDesign';
+import {
+  WIDGET_TEXT_COLOR_PRESETS,
+  WIDGET_BACKGROUND_COLOR_PRESETS,
+} from '../src/constants';
+
+const HEX_COLOR_REGEX = /^#[0-9A-Fa-f]{6}$/;
+
+describe('DEFAULT_WIDGET_DESIGN', () => {
+  it('기획 문서(#169) 기준 기본값을 갖는다', () => {
+    expect(DEFAULT_WIDGET_DESIGN).toEqual({
+      text: { align: 'center', color: '#000000', size: 20, weight: 'bold' },
+      background: { type: 'color', value: 'gradient-default' },
+    });
+  });
+});
+
+describe.each([
+  ['WIDGET_TEXT_COLOR_PRESETS', WIDGET_TEXT_COLOR_PRESETS],
+  ['WIDGET_BACKGROUND_COLOR_PRESETS', WIDGET_BACKGROUND_COLOR_PRESETS],
+])('%s', (_name, presets) => {
+  it('7개(사용자 지정 제외)로 구성된다', () => {
+    expect(presets).toHaveLength(7);
+  });
+
+  it('모든 값이 6자리 hex 색상이다', () => {
+    presets.forEach(color => {
+      expect(color).toMatch(HEX_COLOR_REGEX);
+    });
+  });
+
+  it('중복된 색상이 없다', () => {
+    expect(new Set(presets).size).toBe(presets.length);
+  });
+});

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -6,3 +6,27 @@ export const BRIDGE_INIT_DELAY_MS = 100;
 export const STALE_DATA_THRESHOLD_DAYS = 7;
 /** UserDefaults / App Group key for the currently displayed sermon */
 export const APP_GROUP_DISPLAY_SERMON_KEY = 'displaySermon';
+
+// 위젯 디자인 편집 - 텍스트 색상 스와치 프리셋 (빨강/주황/노랑/초록/파랑/흰색/검정)
+// 8번째 "사용자 지정" 스와치는 프리셋이 아닌 커스텀 컬러피커 진입 버튼이라 이 배열에는 포함하지 않음
+export const WIDGET_TEXT_COLOR_PRESETS: readonly string[] = [
+  '#FF3B30', // 빨강
+  '#FF9500', // 주황
+  '#FFCC00', // 노랑
+  '#34C759', // 초록
+  '#007AFF', // 파랑
+  '#FFFFFF', // 흰색
+  '#000000', // 검정
+];
+
+// 위젯 디자인 편집 - 배경색 스와치 프리셋 (화이트/라이트옐로우/라이트그린/라이트블루/라이트핑크/베이지/다크그레이)
+// 8번째 "사용자 지정" 스와치는 위와 동일하게 이 배열에 포함하지 않음
+export const WIDGET_BACKGROUND_COLOR_PRESETS: readonly string[] = [
+  '#FFFFFF', // 화이트
+  '#FFF9DB', // 라이트옐로우
+  '#E3F9E5', // 라이트그린
+  '#E3F2FD', // 라이트블루
+  '#FDE3EC', // 라이트핑크
+  '#F5E9DA', // 베이지
+  '#2E2E2E', // 다크그레이
+];

--- a/src/types/WidgetDesign.ts
+++ b/src/types/WidgetDesign.ts
@@ -1,0 +1,29 @@
+export type WidgetTextAlign = 'left' | 'center' | 'right';
+export type WidgetTextSize = 16 | 20 | 24 | 28; // 작게/보통/크게/아주크게
+export type WidgetTextWeight = 'regular' | 'bold' | 'extrabold';
+export type WidgetBackgroundType = 'color' | 'gallery';
+
+export interface WidgetImageTransform {
+  zoom: number; // 1.0 = 이미지가 프레임을 빈틈없이 채우는 최소 배율, 최대 3.0
+  focalX: number; // 0~1, 이미지 가로축에서 프레임 중심이 위치하는 지점
+  focalY: number; // 0~1, 이미지 세로축에서 프레임 중심이 위치하는 지점
+}
+
+export interface WidgetDesign {
+  text: {
+    align: WidgetTextAlign;
+    color: string; // hex, 프리셋 중 하나 또는 커스텀
+    size: WidgetTextSize;
+    weight: WidgetTextWeight;
+  };
+  background: {
+    type: WidgetBackgroundType;
+    value: string; // type='color'면 hex, type='gallery'면 원본(또는 다운스케일) 이미지 로컬 경로
+    imageTransform?: WidgetImageTransform; // type='gallery'일 때만 존재
+  };
+}
+
+export const DEFAULT_WIDGET_DESIGN: WidgetDesign = {
+  text: { align: 'center', color: '#000000', size: 20, weight: 'bold' },
+  background: { type: 'color', value: 'gradient-default' }, // 기존 미리보기 그라데이션 배경 유지
+};


### PR DESCRIPTION
## 이슈
Closes #211

## 요약
[#210 RN 공통](https://github.com/MannaDevelopers/meditation_blossom_frontend/issues/210)의 첫 단계. 위젯 디자인 편집 기능([#169] 6절 스키마)에서 쓰일 타입/기본값/프리셋 상수를 정의한다.

## 변경점
- 신규: `src/types/WidgetDesign.ts` — `WidgetDesign`/`WidgetImageTransform` 타입, `DEFAULT_WIDGET_DESIGN`
- `src/constants/index.ts` — 텍스트 색상 프리셋 7종(`WIDGET_TEXT_COLOR_PRESETS`), 배경색 프리셋 7종(`WIDGET_BACKGROUND_COLOR_PRESETS`) 추가 (각 8번째 "사용자 지정" 스와치는 프리셋이 아닌 UI 진입 버튼이라 배열에서 제외)

## 참고
프리셋 hex 값은 기획 문서에 색상명만 명시되어 있어 합리적으로 선택한 값. 실제 디자인 확정본과 다를 수 있어 Figma 대조 후 필요 시 조정 필요.

## 테스트
- [x] `__tests__/WidgetDesign.test.ts` 신규 — 기본값/프리셋 개수/hex 형식/중복 검증, `yarn jest` 통과