### PR TITLE
[ISSUE-212] EditScreen 탭 상태 연동 + 헤더/이탈 다이얼로그

### DIFF
--- a/__tests__/widgetDesignColor.test.ts
+++ b/__tests__/widgetDesignColor.test.ts
@@ -1,0 +1,17 @@
+import { isPresetColor } from '../src/utils/widgetDesignColor';
+
+describe('isPresetColor', () => {
+  const presets = ['#FF3B30', '#34C759'];
+
+  it('프리셋에 포함된 hex는 true', () => {
+    expect(isPresetColor('#FF3B30', presets)).toBe(true);
+  });
+
+  it('대소문자가 달라도 동일 색상이면 true', () => {
+    expect(isPresetColor('#ff3b30', presets)).toBe(true);
+  });
+
+  it('프리셋에 없는 hex(사용자 지정)는 false', () => {
+    expect(isPresetColor('#123456', presets)).toBe(false);
+  });
+});

--- a/src/screens/EditScreen.tsx
+++ b/src/screens/EditScreen.tsx
@@ -1,93 +1,592 @@
-import { View, TouchableOpacity, Text, StatusBar } from 'react-native';
+import { View, TouchableOpacity, Text, StatusBar, Modal, TextInput, Alert } from 'react-native';
 import WidgetPreview from '../components/WidgetPreview';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { usePreventRemove } from '@react-navigation/native';
 import { RootStackParamList } from '../types/navigation';
 import SvgIcon from '../components/SvgIcon';
-import React, {useState} from 'react';
+import React, { useMemo, useState } from 'react';
 import styled from 'styled-components/native';
+import Svg, { Defs, LinearGradient, Stop, Text as SvgText } from 'react-native-svg';
+import {
+  WidgetDesign,
+  WidgetTextAlign,
+  WidgetTextSize,
+  WidgetTextWeight,
+  DEFAULT_WIDGET_DESIGN,
+} from '../types/WidgetDesign';
+import {
+  WIDGET_TEXT_COLOR_PRESETS,
+  WIDGET_BACKGROUND_COLOR_PRESETS,
+} from '../constants';
+import { isPresetColor } from '../utils/widgetDesignColor';
 
-const TextAlignIconBox = styled.TouchableOpacity<{selected: boolean}>`
+type Category = 'text' | 'background';
+type TextSubTab = 'align' | 'color' | 'size' | 'weight';
+type BackgroundSubTab = 'color' | 'gallery';
+
+const CATEGORY_OPTIONS: { key: Category; label: string; icon: 'EditText' | 'EditBackground' }[] = [
+  { key: 'text', label: '텍스트', icon: 'EditText' },
+  { key: 'background', label: '배경', icon: 'EditBackground' },
+];
+
+const TEXT_SUB_TABS: { key: TextSubTab; label: string }[] = [
+  { key: 'align', label: '정렬' },
+  { key: 'color', label: '색상' },
+  { key: 'size', label: '크기' },
+  { key: 'weight', label: '두께' },
+];
+
+const BACKGROUND_SUB_TABS: { key: BackgroundSubTab; label: string }[] = [
+  { key: 'color', label: '배경색' },
+  { key: 'gallery', label: '갤러리' },
+];
+
+const ALIGN_OPTIONS: { key: WidgetTextAlign; icon: 'TextLeft' | 'TextCenter' | 'TextRight' }[] = [
+  { key: 'left', icon: 'TextLeft' },
+  { key: 'center', icon: 'TextCenter' },
+  { key: 'right', icon: 'TextRight' },
+];
+
+const TEXT_SIZE_OPTIONS: WidgetTextSize[] = [16, 20, 24, 28];
+
+const TEXT_WEIGHT_OPTIONS: { key: WidgetTextWeight; label: string; fontFamily: string }[] = [
+  { key: 'regular', label: '보통', fontFamily: 'Pretendard-Regular' },
+  { key: 'bold', label: '굵게', fontFamily: 'Pretendard-Bold' },
+  { key: 'extrabold', label: '아주굵게', fontFamily: 'Pretendard-ExtraBold' },
+];
+
+const DetailCircleBox = styled.TouchableOpacity<{ selected: boolean }>`
   width: 55;
   height: 55;
   justify-content: center;
   align-items: center;
   border-radius: 27px;
-  border-color: ${({selected}) => (selected ? 'white' : 'transparent')};
-  border-width: ${({selected}) => (selected ? '2px' : '0')};
-  `;
+  border-color: ${({ selected }) => (selected ? 'white' : 'transparent')};
+  border-width: ${({ selected }) => (selected ? '2px' : '0')};
+`;
 
-const TextSettingItemBox = styled.Text<{selected: boolean}>`
-  color: ${({selected}) => (selected ? '#FFCD16' : 'white')};
+const DetailRow = styled.View`
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  min-height: 71;
+  margin-bottom: 15;
+`;
+
+const SubMenuItemBox = styled.View`
   width: 61;
   height: 40;
+  justify-content: center;
+  align-items: center;
+`;
+
+const SubMenuPlainText = styled.Text`
+  color: white;
+  width: 61;
   font-size: 16;
   font-weight: bold;
   text-align: center;
   text-align-vertical: center;
 `;
 
-const MainCategoryIconBox = styled.TouchableOpacity<{selected: boolean}>`
+const SubMenuRow = styled.View`
+  flex-direction: row;
+  justify-content: center;
+  gap: 12px;
+  margin-bottom: 15;
+`;
+
+const CategoryRow = styled.View`
+  width: 157;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-horizontal: 74;
+  margin-bottom: 60;
+`;
+
+const CategoryIconBox = styled.TouchableOpacity<{ selected: boolean }>`
   width: 71;
   height: 71;
+  border-radius: 12px;
   justify-content: center;
   align-items: center;
-  background-color: ${({selected}) => (selected ? 'gray' : 'transparent')};
+  background-color: ${({ selected }) => (selected ? 'rgba(255,255,255,0.2)' : 'transparent')};
 `;
+
+const SwatchRow = styled.View`
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  margin-horizontal: 30;
+  margin-bottom: 15;
+`;
+
+const ColorSwatch = styled.TouchableOpacity<{ color: string; selected: boolean }>`
+  width: ${({ selected }) => (selected ? '36px' : '30px')};
+  height: ${({ selected }) => (selected ? '36px' : '30px')};
+  border-radius: 18px;
+  background-color: ${({ color }) => color};
+  justify-content: center;
+  align-items: center;
+  border-color: white;
+  border-width: ${({ selected }) => (selected ? '2px' : '0')};
+`;
+
+const CustomColorSwatch = styled.TouchableOpacity<{ selected: boolean; color?: string }>`
+  width: ${({ selected }) => (selected ? '36px' : '30px')};
+  height: ${({ selected }) => (selected ? '36px' : '30px')};
+  border-radius: 18px;
+  background-color: ${({ color }) => color || 'transparent'};
+  justify-content: center;
+  align-items: center;
+  border-color: ${({ selected }) => (selected ? 'white' : '#888')};
+  border-width: 1.5px;
+  border-style: ${({ color }) => (color ? 'solid' : 'dashed')};
+`;
+
+const SwatchCheck = styled.Text`
+  color: white;
+  font-size: 14;
+  font-weight: bold;
+  text-shadow-color: rgba(0, 0, 0, 0.6);
+  text-shadow-radius: 2px;
+`;
+
+const GalleryPlaceholder = styled.View`
+  height: 90;
+  margin-horizontal: 30;
+  margin-bottom: 15;
+  border-radius: 12px;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(255, 255, 255, 0.05);
+`;
+
+const GalleryPlaceholderText = styled.Text`
+  color: #999;
+  font-size: 14;
+`;
+
+const HeaderRow = styled.View`
+  width: 305;
+  height: 26;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const HeaderRightGroup = styled.View`
+  flex-direction: row;
+  align-items: center;
+  gap: 20px;
+`;
+
+const HeaderResetText = styled.Text`
+  color: #999999;
+  font-weight: bold;
+  font-size: 16;
+`;
+
+const HeaderSaveText = styled.Text`
+  color: white;
+  font-weight: bold;
+  font-size: 20;
+`;
+
+const ModalBackdrop = styled.View`
+  flex: 1;
+  background-color: rgba(0, 0, 0, 0.6);
+  justify-content: center;
+  align-items: center;
+`;
+
+const ModalCard = styled.View`
+  width: 260;
+  background-color: #1c1c1e;
+  border-radius: 16px;
+  padding: 20px;
+`;
+
+const ModalTitle = styled.Text`
+  color: white;
+  font-size: 16;
+  font-weight: bold;
+  margin-bottom: 16;
+`;
+
+const ModalInputRow = styled.View`
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 20;
+`;
+
+const ModalHashPrefix = styled.Text`
+  color: #999999;
+  font-size: 16;
+`;
+
+const ModalInput = styled.TextInput`
+  flex: 1;
+  color: white;
+  font-size: 16;
+  border-bottom-width: 1px;
+  border-bottom-color: #666666;
+  padding-vertical: 4px;
+`;
+
+const ModalPreview = styled.View`
+  width: 24;
+  height: 24;
+  border-radius: 12px;
+  border-width: 1px;
+  border-color: #666666;
+`;
+
+const ModalButtonRow = styled.View`
+  flex-direction: row;
+  justify-content: flex-end;
+  gap: 20px;
+`;
+
+const ModalCancelText = styled.Text`
+  color: #999999;
+  font-size: 16;
+`;
+
+const ModalApplyText = styled.Text<{ disabled: boolean }>`
+  color: ${({ disabled }) => (disabled ? '#555555' : '#FFCD16')};
+  font-size: 16;
+  font-weight: bold;
+`;
+
+const HEX_INPUT_REGEX = /^[0-9A-Fa-f]{6}$/;
+
+const CustomColorModal = ({
+  visible,
+  initialColor,
+  onCancel,
+  onApply,
+}: {
+  visible: boolean;
+  initialColor: string;
+  onCancel: () => void;
+  onApply: (hex: string) => void;
+}) => {
+  const [text, setText] = useState(initialColor.replace('#', ''));
+
+  const normalized = text.trim().toUpperCase();
+  const isValid = HEX_INPUT_REGEX.test(normalized);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onCancel}
+      onShow={() => setText(initialColor.replace('#', ''))}
+    >
+      <ModalBackdrop>
+        <ModalCard>
+          <ModalTitle>사용자 지정 색상</ModalTitle>
+          <ModalInputRow>
+            <ModalHashPrefix>#</ModalHashPrefix>
+            <ModalInput
+              value={text}
+              onChangeText={setText}
+              placeholder="000000"
+              placeholderTextColor="#666666"
+              maxLength={6}
+              autoCapitalize="characters"
+              autoCorrect={false}
+            />
+            <ModalPreview style={{ backgroundColor: isValid ? `#${normalized}` : 'transparent' }} />
+          </ModalInputRow>
+          <ModalButtonRow>
+            <TouchableOpacity onPress={onCancel}>
+              <ModalCancelText>취소</ModalCancelText>
+            </TouchableOpacity>
+            <TouchableOpacity disabled={!isValid} onPress={() => onApply(`#${normalized}`)}>
+              <ModalApplyText disabled={!isValid}>적용</ModalApplyText>
+            </TouchableOpacity>
+          </ModalButtonRow>
+        </ModalCard>
+      </ModalBackdrop>
+    </Modal>
+  );
+};
+
+const GradientSubTabLabel = ({ label }: { label: string }) => (
+  <Svg width={61} height={24}>
+    <Defs>
+      <LinearGradient id="subTabGradient" x1="0" y1="0" x2="1" y2="0">
+        <Stop offset="0" stopColor="#FFCD16" />
+        <Stop offset="1" stopColor="#FF7E00" />
+      </LinearGradient>
+    </Defs>
+    <SvgText x="50%" y="17" fontSize={16} fontWeight="bold" textAnchor="middle" fill="url(#subTabGradient)">
+      {label}
+    </SvgText>
+  </Svg>
+);
+
+const ColorSwatchRow = ({
+  currentColor,
+  presets,
+  onSelectPreset,
+  onOpenCustom,
+}: {
+  currentColor: string;
+  presets: readonly string[];
+  onSelectPreset: (hex: string) => void;
+  onOpenCustom: () => void;
+}) => {
+  const customSelected = !isPresetColor(currentColor, presets);
+  return (
+    <SwatchRow>
+      {presets.map(hex => {
+        const selected = hex.toUpperCase() === currentColor.toUpperCase();
+        return (
+          <ColorSwatch key={hex} color={hex} selected={selected} onPress={() => onSelectPreset(hex)}>
+            {selected && <SwatchCheck>✓</SwatchCheck>}
+          </ColorSwatch>
+        );
+      })}
+      <CustomColorSwatch
+        selected={customSelected}
+        color={customSelected ? currentColor : undefined}
+        onPress={onOpenCustom}
+      >
+        {customSelected ? <SwatchCheck>✓</SwatchCheck> : <Text style={{ color: 'white', fontSize: 16 }}>+</Text>}
+      </CustomColorSwatch>
+    </SwatchRow>
+  );
+};
 
 type Props = NativeStackScreenProps<RootStackParamList, 'EditScreen'>;
 
-const EditScreen = ({navigation, route}: Props) => {
-  const [textAlignIconSelected, setTextAlignIconSelected] = useState<number>(0);
-  const [textSettingItemSelected, setTextSettingItemSelected] = useState<number>(0);
-  const [mainCategorySelected, setMainCategorySelected] = useState<number>(0);
+const EditScreen = ({ navigation, route }: Props) => {
   const sermon = route.params?.sermon;
-  return (
-    <View style={{flex: 1, backgroundColor:'black'}}>
-      <StatusBar barStyle="light-content" backgroundColor="black" />
-      <View style={{ flex: 1, backgroundColor: 'black', marginHorizontal: 35, marginVertical: 60, justifyContent: 'center', alignItems: 'center' }}>
-      <View style={{backgroundColor: 'transparent', width: 305, height: 26, flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center'}}>
-        <TouchableOpacity onPress={() => {navigation.goBack();}}><SvgIcon name="BackButton" size={20} /></TouchableOpacity>
-        <TouchableOpacity><Text style={{color: 'white', fontWeight: 'bold', fontSize: 20, textAlign: 'center', textAlignVertical: 'center'}}>저장</Text></TouchableOpacity>
-      </View>
-      <View style={{ backgroundColor: 'transparent', marginVertical: 105, borderRadius: 20 }} >
-        <WidgetPreview content={sermon?.content} />
-      </View>
-      {/*Edit Tab*/}
-      {/*Tab 1*/} 
-      <View style={{ backgroundColor: 'black', width: 177, flexDirection: 'row', justifyContent: 'space-between', marginHorizontal: 64, marginVertical: 15}} >
-        <TextAlignIconBox selected={textAlignIconSelected === 0} onPress={() => setTextAlignIconSelected(0)} >
-          <SvgIcon name="TextLeft" size={25} fill='black'/>
-        </TextAlignIconBox>
-        <TextAlignIconBox selected={textAlignIconSelected === 1} onPress={() => setTextAlignIconSelected(1)} >
-          <SvgIcon name="TextCenter" size={25}/>
-        </TextAlignIconBox>
-        <TextAlignIconBox selected={textAlignIconSelected === 2} onPress={() => setTextAlignIconSelected(2)} >
-          <SvgIcon name="TextRight" size={25} />
-        </TextAlignIconBox>
-      </View>
-{/* Tab 2 */}
-<View style={{backgroundColor: 'black', flexDirection: 'row', width: 245, height: 40, marginHorizontal: 30, marginBottom: 15}} >
-<TouchableOpacity onPress={() => setTextSettingItemSelected(0)}><TextSettingItemBox selected={textSettingItemSelected === 0}>정렬</TextSettingItemBox></TouchableOpacity>
-<TouchableOpacity onPress={() => setTextSettingItemSelected(1)}><TextSettingItemBox selected={textSettingItemSelected === 1}>색상</TextSettingItemBox></TouchableOpacity>
-<TouchableOpacity onPress={() => setTextSettingItemSelected(2)}><TextSettingItemBox selected={textSettingItemSelected === 2}>크기</TextSettingItemBox></TouchableOpacity>
-<TouchableOpacity onPress={() => setTextSettingItemSelected(3)}><TextSettingItemBox selected={textSettingItemSelected === 3}>두께</TextSettingItemBox></TouchableOpacity>
-</View>
-{/* Tab 3 */}
-<View style={{backgroundColor: 'transparent', flexDirection: 'row', width: 243, height: 71, marginHorizontal: 31, marginBottom: 60, justifyContent: 'space-between', alignItems: 'center'}} >
-<MainCategoryIconBox selected={mainCategorySelected === 0} onPress={() => setMainCategorySelected(0)}>
-<SvgIcon name="EditText" size={35}/>
-</MainCategoryIconBox>
-<MainCategoryIconBox selected={mainCategorySelected === 1} onPress={() => setMainCategorySelected(1)}>
-<SvgIcon name="EditBackground" size={35}/>
-</MainCategoryIconBox>
-<MainCategoryIconBox selected={mainCategorySelected === 2} onPress={() => setMainCategorySelected(2)}>
-<SvgIcon name="EditStyle" size={35}/>
-</MainCategoryIconBox>
-  </View>
 
-</View>
-</View>
-);
-}
+  const [savedDesign, setSavedDesign] = useState<WidgetDesign>(DEFAULT_WIDGET_DESIGN);
+  const [draftDesign, setDraftDesign] = useState<WidgetDesign>(DEFAULT_WIDGET_DESIGN);
+  const [category, setCategory] = useState<Category>('text');
+  const [textSubTab, setTextSubTab] = useState<TextSubTab>('align');
+  const [backgroundSubTab, setBackgroundSubTab] = useState<BackgroundSubTab>('color');
+  const [customColorTarget, setCustomColorTarget] = useState<'text' | 'background' | null>(null);
+
+  const activeSubTab = category === 'text' ? textSubTab : backgroundSubTab;
+
+  const hasUnsavedChanges = useMemo(
+    () => JSON.stringify(draftDesign) !== JSON.stringify(savedDesign),
+    [draftDesign, savedDesign],
+  );
+
+  usePreventRemove(hasUnsavedChanges, ({ data }) => {
+    Alert.alert(
+      '변경사항을 저장하지 않았습니다',
+      '지금 나가면 편집한 내용이 사라집니다.',
+      [
+        { text: '계속 편집', style: 'cancel' },
+        { text: '나가기', style: 'destructive', onPress: () => navigation.dispatch(data.action) },
+      ],
+    );
+  });
+
+  const handleReset = () => {
+    Alert.alert(
+      '기본값으로 되돌릴까요?',
+      '지금까지 편집한 내용이 모두 사라집니다.',
+      [
+        { text: '취소', style: 'cancel' },
+        { text: '되돌리기', style: 'destructive', onPress: () => setDraftDesign(DEFAULT_WIDGET_DESIGN) },
+      ],
+    );
+  };
+
+  const handleSave = () => {
+    setSavedDesign(draftDesign);
+    navigation.goBack();
+  };
+
+  const updateText = (patch: Partial<WidgetDesign['text']>) =>
+    setDraftDesign(prev => ({ ...prev, text: { ...prev.text, ...patch } }));
+
+  const updateBackgroundColor = (hex: string) =>
+    setDraftDesign(prev => ({ ...prev, background: { type: 'color', value: hex } }));
+
+  const renderDetailTab = () => {
+    if (category === 'text') {
+      switch (textSubTab) {
+        case 'align':
+          return (
+            <DetailRow>
+              {ALIGN_OPTIONS.map(opt => (
+                <DetailCircleBox
+                  key={opt.key}
+                  selected={draftDesign.text.align === opt.key}
+                  onPress={() => updateText({ align: opt.key })}
+                >
+                  <SvgIcon name={opt.icon} size={25} />
+                </DetailCircleBox>
+              ))}
+            </DetailRow>
+          );
+        case 'color':
+          return (
+            <ColorSwatchRow
+              currentColor={draftDesign.text.color}
+              presets={WIDGET_TEXT_COLOR_PRESETS}
+              onSelectPreset={hex => updateText({ color: hex })}
+              onOpenCustom={() => setCustomColorTarget('text')}
+            />
+          );
+        case 'size':
+          return (
+            <DetailRow>
+              {TEXT_SIZE_OPTIONS.map(size => (
+                <DetailCircleBox
+                  key={size}
+                  selected={draftDesign.text.size === size}
+                  onPress={() => updateText({ size })}
+                >
+                  <Text style={{ fontSize: Math.min(size, 30), fontFamily: 'Pretendard-Bold', color: 'white' }}>
+                    가
+                  </Text>
+                </DetailCircleBox>
+              ))}
+            </DetailRow>
+          );
+        case 'weight':
+          return (
+            <DetailRow>
+              {TEXT_WEIGHT_OPTIONS.map(opt => (
+                <DetailCircleBox
+                  key={opt.key}
+                  selected={draftDesign.text.weight === opt.key}
+                  onPress={() => updateText({ weight: opt.key })}
+                >
+                  <Text style={{ fontSize: 20, fontFamily: opt.fontFamily, color: 'white' }}>가</Text>
+                </DetailCircleBox>
+              ))}
+            </DetailRow>
+          );
+        default:
+          return null;
+      }
+    }
+
+    switch (backgroundSubTab) {
+      case 'color':
+        return (
+          <ColorSwatchRow
+            currentColor={draftDesign.background.type === 'color' ? draftDesign.background.value : '#FFFFFF'}
+            presets={WIDGET_BACKGROUND_COLOR_PRESETS}
+            onSelectPreset={hex => updateBackgroundColor(hex)}
+            onOpenCustom={() => setCustomColorTarget('background')}
+          />
+        );
+      case 'gallery':
+        return (
+          <GalleryPlaceholder>
+            <GalleryPlaceholderText>사진 배경은 곧 추가됩니다</GalleryPlaceholderText>
+          </GalleryPlaceholder>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <View style={{ flex: 1, backgroundColor: 'black' }}>
+      <StatusBar barStyle="light-content" backgroundColor="black" />
+      <View
+        style={{
+          flex: 1,
+          backgroundColor: 'black',
+          marginHorizontal: 35,
+          marginVertical: 60,
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <HeaderRow>
+          <TouchableOpacity
+            onPress={() => navigation.goBack()}
+            hitSlop={{ top: 20, bottom: 20, left: 20, right: 20 }}
+          >
+            <SvgIcon name="BackButton" size={20} />
+          </TouchableOpacity>
+          <HeaderRightGroup>
+            <TouchableOpacity onPress={handleReset}>
+              <HeaderResetText>초기화</HeaderResetText>
+            </TouchableOpacity>
+            <TouchableOpacity onPress={handleSave}>
+              <HeaderSaveText>저장</HeaderSaveText>
+            </TouchableOpacity>
+          </HeaderRightGroup>
+        </HeaderRow>
+
+        <View style={{ backgroundColor: 'transparent', marginVertical: 105, borderRadius: 20 }}>
+          <WidgetPreview content={sermon?.content} />
+        </View>
+
+        {/* 3번 탭: 2번 탭 선택에 따른 세부 옵션, 미리보기 바로 아래 */}
+        {renderDetailTab()}
+
+        {/* 2번 탭: 1번 탭 선택에 따른 하위 그룹 메뉴 */}
+        <SubMenuRow>
+          {(category === 'text' ? TEXT_SUB_TABS : BACKGROUND_SUB_TABS).map(item => {
+            const selected = activeSubTab === item.key;
+            return (
+              <TouchableOpacity
+                key={item.key}
+                onPress={() =>
+                  category === 'text'
+                    ? setTextSubTab(item.key as TextSubTab)
+                    : setBackgroundSubTab(item.key as BackgroundSubTab)
+                }
+              >
+                <SubMenuItemBox>
+                  {selected ? <GradientSubTabLabel label={item.label} /> : <SubMenuPlainText>{item.label}</SubMenuPlainText>}
+                </SubMenuItemBox>
+              </TouchableOpacity>
+            );
+          })}
+        </SubMenuRow>
+
+        {/* 1번 탭: 최상위 카테고리(텍스트/배경), 화면 맨 아래 */}
+        <CategoryRow>
+          {CATEGORY_OPTIONS.map(opt => (
+            <CategoryIconBox key={opt.key} selected={category === opt.key} onPress={() => setCategory(opt.key)}>
+              <SvgIcon name={opt.icon} size={35} />
+            </CategoryIconBox>
+          ))}
+        </CategoryRow>
+      </View>
+
+      <CustomColorModal
+        visible={customColorTarget !== null}
+        initialColor={
+          customColorTarget === 'background'
+            ? draftDesign.background.type === 'color'
+              ? draftDesign.background.value
+              : '#FFFFFF'
+            : draftDesign.text.color
+        }
+        onCancel={() => setCustomColorTarget(null)}
+        onApply={hex => {
+          if (customColorTarget === 'text') updateText({ color: hex });
+          if (customColorTarget === 'background') updateBackgroundColor(hex);
+          setCustomColorTarget(null);
+        }}
+      />
+    </View>
+  );
+};
 
 export default EditScreen;

--- a/src/utils/widgetDesignColor.ts
+++ b/src/utils/widgetDesignColor.ts
@@ -1,0 +1,3 @@
+export function isPresetColor(hex: string, presets: readonly string[]): boolean {
+  return presets.some(preset => preset.toUpperCase() === hex.toUpperCase());
+}


### PR DESCRIPTION
## 이슈
Closes #212

**주의**: [PR #222 (#211)](https://github.com/MannaDevelopers/meditation_blossom_frontend/pull/222) 위에 쌓은 브랜치라 base를 `feature/issue-211`로 잡았습니다. #211이 머지되면 이 PR의 base가 자동으로 `main`으로 재조정됩니다(GitHub 기본 동작).

## 요약
[#210 RN 공통](https://github.com/MannaDevelopers/meditation_blossom_frontend/issues/210)의 두 번째 단계. `EditScreen`의 로컬 `useState` 골격을 실제 `draftDesign: WidgetDesign` 상태로 연결하고, 헤더(초기화/저장)와 이탈 확인 다이얼로그를 구현했다.

## 변경점
- `EditScreen.tsx` 전면 재작성
  - 1번 탭(텍스트/배경 카테고리, 71×71, gap 15, 좌우 여백 74) / 2번 탭(하위 메뉴, 선택 시 그라데이션 텍스트 — `react-native-svg`로 구현, 신규 의존성 없음) / 3번 탭(세부 값 선택) 3단 구조를 `draftDesign` 상태에 연결
  - 3번 탭 세부 UI 신규 구현: 정렬(기존 아이콘 재사용), 색상/배경색 스와치(프리셋 7종 + 사용자 지정 hex 입력 모달), 크기 4단계, 두께 3단계
  - 배경 > 갤러리는 [#214](https://github.com/MannaDevelopers/meditation_blossom_frontend/issues/214) 범위라 플레이스홀더만 표시
  - 헤더: 초기화(확인 다이얼로그 → `DEFAULT_WIDGET_DESIGN` 복원) / 저장(`draftDesign` → `savedDesign` 커밋 후 뒤로가기)
  - 화면 이탈 시 미저장 변경사항이 있으면 확인 다이얼로그 (`usePreventRemove`)
- 신규: `src/utils/widgetDesignColor.ts` (`isPresetColor` — 스와치가 프리셋인지 사용자 지정인지 판별하는 순수 함수)

## 범위 밖 (별도 이슈에서 진행)
- `WidgetPreview`가 `draftDesign`을 실시간으로 반영하는 것 — 아직 `content`만 전달 ([#213](https://github.com/MannaDevelopers/meditation_blossom_frontend/issues/213))
- 배경 갤러리 이미지 피커/크롭 ([#214](https://github.com/MannaDevelopers/meditation_blossom_frontend/issues/214))
- 저장된 디자인의 네이티브/영구 반영 (Android/iOS 브릿지, [#216](https://github.com/MannaDevelopers/meditation_blossom_frontend/issues/216)/[#220](https://github.com/MannaDevelopers/meditation_blossom_frontend/issues/220))
- 화면 진입 버튼 — 신규 [#223](https://github.com/MannaDevelopers/meditation_blossom_frontend/issues/223)로 분리 (현재 코드베이스에 `EditScreen` 진입 지점이 없다는 걸 확인, 현재 탭의 설교 데이터를 헤더까지 끌어올리는 별도 설계가 필요해 이번 PR 범위에서 제외)

## 테스트
- [x] `__tests__/widgetDesignColor.test.ts` 신규, `yarn jest` 통과
- [ ] (리뷰어 수동 확인) 1/2/3번 탭 전환, 값 선택 시 상태 반영, 사용자 지정 색상 입력, 초기화/저장/이탈 다이얼로그 동작 — 아직 화면 진입 지점이 없어([#223]) 임시로 `navigation.navigate('EditScreen')`를 걸어 확인 필요