### PR TITLE
[ISSUE-213] WidgetPreview 실시간 반영 + 배너/카드 스와이프 미리보기

### DIFF
--- a/__tests__/widgetDesignColor.test.ts
+++ b/__tests__/widgetDesignColor.test.ts
@@ -1,4 +1,4 @@
-import { isPresetColor } from '../src/utils/widgetDesignColor';
+import { isPresetColor, getHexLightness, lightenHexColor } from '../src/utils/widgetDesignColor';
 
 describe('isPresetColor', () => {
   const presets = ['#FF3B30', '#34C759'];
@@ -13,5 +13,33 @@ describe('isPresetColor', () => {
 
   it('프리셋에 없는 hex(사용자 지정)는 false', () => {
     expect(isPresetColor('#123456', presets)).toBe(false);
+  });
+});
+
+describe('lightenHexColor', () => {
+  it('명도를 delta만큼 올린다', () => {
+    const original = '#808080'; // L=50
+    const lightened = lightenHexColor(original, 18);
+    expect(getHexLightness(lightened)).toBeCloseTo(68, 0);
+  });
+
+  it('95% 상한을 넘지 않는다', () => {
+    const lightened = lightenHexColor('#2E2E2E', 80); // L=18 + 80 = 98 -> clamp 95
+    expect(getHexLightness(lightened)).toBeLessThanOrEqual(95);
+  });
+
+  it('이미 밝은 색(흰색)은 95% 상한으로 살짝 눌릴 뿐 크게 달라지지 않는다', () => {
+    const lightened = lightenHexColor('#FFFFFF', 18);
+    expect(getHexLightness(lightened)).toBeCloseTo(95, 0);
+  });
+
+  it('색조를 유지한다 (빨강 계열은 여전히 빨강 계열)', () => {
+    const lightened = lightenHexColor('#CC0000', 15);
+    // 밝아진 빨강이므로 R 채널이 G/B보다 여전히 커야 한다
+    const r = parseInt(lightened.slice(1, 3), 16);
+    const g = parseInt(lightened.slice(3, 5), 16);
+    const b = parseInt(lightened.slice(5, 7), 16);
+    expect(r).toBeGreaterThan(g);
+    expect(r).toBeGreaterThan(b);
   });
 });

--- a/src/components/WidgetPreview.tsx
+++ b/src/components/WidgetPreview.tsx
@@ -1,50 +1,305 @@
-import { useMemo } from 'react';
-import { ImageBackground, StyleSheet, Text, View } from 'react-native';
+import { useMemo, useState } from 'react';
+import {
+  ImageBackground,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextStyle,
+  View,
+} from 'react-native';
 import { extractContent } from '../utils/sermonParser';
+import { WidgetDesign } from '../types/WidgetDesign';
+import { WIDGET_TEXT_WEIGHT_FONT_FAMILY } from '../constants';
+import { lightenHexColor } from '../utils/widgetDesignColor';
 
-const WidgetPreview = ({ content }: { content: string | undefined }) => {
-  const extractedContent = useMemo(
+const FRAME_WIDTH = 305;
+const FRAME_HEIGHT = 480;
+
+// Android Large 위젯 최소 크기 비율(245:115dp, [#169] 3.6절)
+const BANNER_CARD_WIDTH = 265;
+const BANNER_CARD_HEIGHT = Math.round((BANNER_CARD_WIDTH * 115) / 245);
+
+// Android Small 위젯 최소 크기 비율(177:115dp)
+const CARD_OUTER_WIDTH = 265;
+const CARD_OUTER_HEIGHT = Math.round((CARD_OUTER_WIDTH * 115) / 177);
+const CARD_TITLE_HEIGHT = 40;
+const CARD_INNER_MARGIN = 10;
+
+const CARD_BACKGROUND_LIGHTEN_DELTA = 18;
+const GALLERY_SCRIM_OPACITY = 0.38;
+
+const CARD_INDEX_GRADIENT = require('../assets/image/BackgroundImg.png');
+
+type PreviewText = { index: string; content: string };
+
+function resolveTextStyle(design: WidgetDesign): TextStyle {
+  return {
+    textAlign: design.text.align,
+    fontFamily: WIDGET_TEXT_WEIGHT_FONT_FAMILY[design.text.weight],
+    fontSize: design.text.size,
+    color: design.text.color,
+  };
+}
+
+// 배경 타입/값에 따른 렌더링 분기 — 두 프리뷰(배너형/카드형) 공통 판별 로직
+function resolveBackgroundKind(design: WidgetDesign): 'gallery' | 'default-gradient' | 'solid' {
+  if (design.background.type === 'gallery') return 'gallery';
+  if (design.background.value === 'gradient-default') return 'default-gradient';
+  return 'solid';
+}
+
+const BannerPreview = ({ index, content, design }: PreviewText & { design: WidgetDesign }) => {
+  const textStyle = resolveTextStyle(design);
+  const backgroundKind = resolveBackgroundKind(design);
+
+  const inner = (
+    <View style={styles.bannerInner}>
+      <Text allowFontScaling={false} style={[styles.bannerContentText, textStyle]}>
+        {content}
+      </Text>
+      <Text allowFontScaling={false} style={[styles.bannerIndexText, textStyle]}>
+        {index}
+      </Text>
+    </View>
+  );
+
+  if (backgroundKind === 'gallery') {
+    return (
+      <ImageBackground
+        source={{ uri: design.background.value }}
+        style={styles.bannerCard}
+        imageStyle={styles.cardRadius}
+      >
+        {inner}
+      </ImageBackground>
+    );
+  }
+
+  if (backgroundKind === 'default-gradient') {
+    return (
+      <ImageBackground source={CARD_INDEX_GRADIENT} style={styles.bannerCard} imageStyle={styles.cardRadius}>
+        {inner}
+      </ImageBackground>
+    );
+  }
+
+  return (
+    <View style={[styles.bannerCard, { backgroundColor: (design.background as { value: string }).value }]}>
+      {inner}
+    </View>
+  );
+};
+
+// 카드형(Small) 위젯의 이중 레이어 재해석([#169] 3.7절):
+// - 배경색: 제목 영역은 본문 카드보다 밝은 동일 계열 톤 (배너형과 구분되도록)
+// - 배경 갤러리: 사진을 전체 배경으로 깔고, 본문 카드 자리를 반투명 검정 스크림으로 재해석
+const CardPreview = ({ index, content, design }: PreviewText & { design: WidgetDesign }) => {
+  const textStyle = resolveTextStyle(design);
+  const backgroundKind = resolveBackgroundKind(design);
+
+  if (backgroundKind === 'gallery') {
+    return (
+      <ImageBackground
+        source={{ uri: design.background.value }}
+        style={styles.cardOuter}
+        imageStyle={styles.cardRadius}
+      >
+        <Text allowFontScaling={false} style={[styles.cardTitleOnPhoto, textStyle]}>
+          {index}
+        </Text>
+        <View style={styles.cardScrim}>
+          <Text allowFontScaling={false} style={[styles.cardContentText, textStyle]}>
+            {content}
+          </Text>
+        </View>
+      </ImageBackground>
+    );
+  }
+
+  if (backgroundKind === 'default-gradient') {
+    return (
+      <View style={styles.cardOuterWhite}>
+        <Text allowFontScaling={false} style={[styles.cardTitleDark, textStyle]}>
+          {index}
+        </Text>
+        <ImageBackground source={CARD_INDEX_GRADIENT} style={styles.cardInner} imageStyle={styles.cardInnerRadius}>
+          <Text allowFontScaling={false} style={[styles.cardContentText, textStyle]}>
+            {content}
+          </Text>
+        </ImageBackground>
+      </View>
+    );
+  }
+
+  const solidColor = (design.background as { value: string }).value;
+  const titleTint = lightenHexColor(solidColor, CARD_BACKGROUND_LIGHTEN_DELTA);
+
+  return (
+    <View style={[styles.cardOuterWhite, { backgroundColor: titleTint }]}>
+      <Text allowFontScaling={false} style={[styles.cardTitleDark, textStyle]}>
+        {index}
+      </Text>
+      <View style={[styles.cardInner, { backgroundColor: solidColor }]}>
+        <Text allowFontScaling={false} style={[styles.cardContentText, textStyle]}>
+          {content}
+        </Text>
+      </View>
+    </View>
+  );
+};
+
+const WidgetPreview = ({ content, design }: { content: string | undefined; design: WidgetDesign }) => {
+  const [activePage, setActivePage] = useState(0);
+  const extracted = useMemo<PreviewText>(
     () => (content ? extractContent(content) : { index: '', content: '' }),
     [content],
   );
 
+  const handleMomentumScrollEnd = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const page = Math.round(e.nativeEvent.contentOffset.x / FRAME_WIDTH);
+    setActivePage(page);
+  };
+
   return (
-    <ImageBackground
-      source={require('../assets/image/BackgroundImg.png')}
-      style={styles.background}
-    >
-      <View style={styles.inner}>
-        <Text style={styles.contentText}>{extractedContent.content}</Text>
-        <Text style={styles.indexText}>{extractedContent.index}</Text>
+    <View style={styles.frame}>
+      <ScrollView
+        horizontal
+        pagingEnabled
+        showsHorizontalScrollIndicator={false}
+        onMomentumScrollEnd={handleMomentumScrollEnd}
+        style={styles.scrollView}
+      >
+        <View style={styles.page}>
+          <BannerPreview index={extracted.index} content={extracted.content} design={design} />
+        </View>
+        <View style={styles.page}>
+          <CardPreview index={extracted.index} content={extracted.content} design={design} />
+        </View>
+      </ScrollView>
+      <View style={styles.indicatorRow}>
+        <View style={[styles.dot, activePage === 0 && styles.dotActive]} />
+        <View style={[styles.dot, activePage === 1 && styles.dotActive]} />
       </View>
-    </ImageBackground>
+    </View>
   );
 };
 
 const styles = StyleSheet.create({
-  background: {
-    backgroundColor: 'transparent',
-    width: 300,
-    height: 270,
+  frame: {
+    width: FRAME_WIDTH,
+    alignItems: 'center',
+  },
+  scrollView: {
+    width: FRAME_WIDTH,
+    height: FRAME_HEIGHT,
+  },
+  page: {
+    width: FRAME_WIDTH,
+    height: FRAME_HEIGHT,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  cardRadius: {
     borderRadius: 15,
   },
-  inner: {
-    backgroundColor: 'transparent',
-    marginVertical: 50,
-    marginHorizontal: 30,
+  // 배너형(Large)
+  bannerCard: {
+    width: BANNER_CARD_WIDTH,
+    height: BANNER_CARD_HEIGHT,
+    borderRadius: 15,
+    overflow: 'hidden',
   },
-  contentText: {
-    color: 'black',
-    fontSize: 20,
+  bannerInner: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  bannerContentText: {
     lineHeight: 24,
     fontWeight: 'bold',
-    marginBottom: 30,
-    fontFamily: 'Pretendard-Regular',
+    marginBottom: 8,
   },
-  indexText: {
+  bannerIndexText: {
+    fontSize: 13,
+    opacity: 0.8,
+  },
+  // 카드형(Small) — 이중 레이어
+  cardOuter: {
+    width: CARD_OUTER_WIDTH,
+    height: CARD_OUTER_HEIGHT,
+    borderRadius: 15,
+    overflow: 'hidden',
+  },
+  cardOuterWhite: {
+    width: CARD_OUTER_WIDTH,
+    height: CARD_OUTER_HEIGHT,
+    borderRadius: 15,
+    backgroundColor: 'white',
+    overflow: 'hidden',
+  },
+  cardTitleDark: {
+    height: CARD_TITLE_HEIGHT,
+    paddingHorizontal: 12,
     color: 'black',
-    fontSize: 16,
-    fontFamily: 'Pretendard-Regular',
+    fontSize: 13,
+    textAlignVertical: 'center',
+  },
+  cardTitleOnPhoto: {
+    height: CARD_TITLE_HEIGHT,
+    paddingHorizontal: 12,
+    fontSize: 13,
+    textAlignVertical: 'center',
+    textShadowColor: 'rgba(0,0,0,0.6)',
+    textShadowRadius: 3,
+    textShadowOffset: { width: 0, height: 1 },
+  },
+  cardInner: {
+    flex: 1,
+    marginHorizontal: CARD_INNER_MARGIN,
+    marginBottom: CARD_INNER_MARGIN,
+    borderRadius: 10,
+    justifyContent: 'center',
+    paddingHorizontal: 12,
+    overflow: 'hidden',
+  },
+  cardInnerRadius: {
+    borderRadius: 10,
+  },
+  cardScrim: {
+    flex: 1,
+    marginHorizontal: CARD_INNER_MARGIN,
+    marginBottom: CARD_INNER_MARGIN,
+    borderRadius: 10,
+    justifyContent: 'center',
+    paddingHorizontal: 12,
+    backgroundColor: `rgba(0,0,0,${GALLERY_SCRIM_OPACITY})`,
+  },
+  cardContentText: {
+    fontSize: 14,
+    lineHeight: 18,
+    fontWeight: 'bold',
+  },
+  indicatorRow: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 6,
+    marginTop: 10,
+  },
+  dot: {
+    width: 5,
+    height: 5,
+    borderRadius: 2.5,
+    backgroundColor: 'rgba(255,255,255,0.4)',
+  },
+  dotActive: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: 'white',
   },
 });
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,5 @@
+import { WidgetTextWeight } from '../types/WidgetDesign';
+
 /** Interval (ms) for polling iOS App Group data for background FCM updates */
 export const APP_GROUP_POLL_INTERVAL_MS = 5000;
 /** Workaround delay (ms) for iOS native bridge not being ready immediately after app launch */
@@ -30,3 +32,10 @@ export const WIDGET_BACKGROUND_COLOR_PRESETS: readonly string[] = [
   '#F5E9DA', // 베이지
   '#2E2E2E', // 다크그레이
 ];
+
+// 위젯 디자인 편집 - 텍스트 두께(WidgetTextWeight) → 실제 렌더링에 쓰는 Pretendard 폰트 패밀리
+export const WIDGET_TEXT_WEIGHT_FONT_FAMILY: Record<WidgetTextWeight, string> = {
+  regular: 'Pretendard-Regular',
+  bold: 'Pretendard-Bold',
+  extrabold: 'Pretendard-ExtraBold',
+};

--- a/src/screens/EditScreen.tsx
+++ b/src/screens/EditScreen.tsx
@@ -17,6 +17,7 @@ import {
 import {
   WIDGET_TEXT_COLOR_PRESETS,
   WIDGET_BACKGROUND_COLOR_PRESETS,
+  WIDGET_TEXT_WEIGHT_FONT_FAMILY,
 } from '../constants';
 import { isPresetColor } from '../utils/widgetDesignColor';
 
@@ -49,10 +50,10 @@ const ALIGN_OPTIONS: { key: WidgetTextAlign; icon: 'TextLeft' | 'TextCenter' | '
 
 const TEXT_SIZE_OPTIONS: WidgetTextSize[] = [16, 20, 24, 28];
 
-const TEXT_WEIGHT_OPTIONS: { key: WidgetTextWeight; label: string; fontFamily: string }[] = [
-  { key: 'regular', label: '보통', fontFamily: 'Pretendard-Regular' },
-  { key: 'bold', label: '굵게', fontFamily: 'Pretendard-Bold' },
-  { key: 'extrabold', label: '아주굵게', fontFamily: 'Pretendard-ExtraBold' },
+const TEXT_WEIGHT_OPTIONS: { key: WidgetTextWeight; label: string }[] = [
+  { key: 'regular', label: '보통' },
+  { key: 'bold', label: '굵게' },
+  { key: 'extrabold', label: '아주굵게' },
 ];
 
 const DetailCircleBox = styled.TouchableOpacity<{ selected: boolean }>`
@@ -454,7 +455,10 @@ const EditScreen = ({ navigation, route }: Props) => {
                   selected={draftDesign.text.size === size}
                   onPress={() => updateText({ size })}
                 >
-                  <Text style={{ fontSize: Math.min(size, 30), fontFamily: 'Pretendard-Bold', color: 'white' }}>
+                  <Text
+                    allowFontScaling={false}
+                    style={{ fontSize: Math.min(size, 30), fontFamily: 'Pretendard-Bold', color: 'white' }}
+                  >
                     가
                   </Text>
                 </DetailCircleBox>
@@ -470,7 +474,12 @@ const EditScreen = ({ navigation, route }: Props) => {
                   selected={draftDesign.text.weight === opt.key}
                   onPress={() => updateText({ weight: opt.key })}
                 >
-                  <Text style={{ fontSize: 20, fontFamily: opt.fontFamily, color: 'white' }}>가</Text>
+                  <Text
+                    allowFontScaling={false}
+                    style={{ fontSize: 20, fontFamily: WIDGET_TEXT_WEIGHT_FONT_FAMILY[opt.key], color: 'white' }}
+                  >
+                    가
+                  </Text>
                 </DetailCircleBox>
               ))}
             </DetailRow>
@@ -532,7 +541,7 @@ const EditScreen = ({ navigation, route }: Props) => {
         </HeaderRow>
 
         <View style={{ backgroundColor: 'transparent', marginVertical: 105, borderRadius: 20 }}>
-          <WidgetPreview content={sermon?.content} />
+          <WidgetPreview content={sermon?.content} design={draftDesign} />
         </View>
 
         {/* 3번 탭: 2번 탭 선택에 따른 세부 옵션, 미리보기 바로 아래 */}

--- a/src/utils/widgetDesignColor.ts
+++ b/src/utils/widgetDesignColor.ts
@@ -1,3 +1,98 @@
 export function isPresetColor(hex: string, presets: readonly string[]): boolean {
   return presets.some(preset => preset.toUpperCase() === hex.toUpperCase());
 }
+
+interface Hsl {
+  h: number; // 0~360
+  s: number; // 0~100
+  l: number; // 0~100
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const normalized = hex.replace('#', '');
+  return {
+    r: parseInt(normalized.substring(0, 2), 16),
+    g: parseInt(normalized.substring(2, 4), 16),
+    b: parseInt(normalized.substring(4, 6), 16),
+  };
+}
+
+function rgbToHsl(r: number, g: number, b: number): Hsl {
+  const rNorm = r / 255;
+  const gNorm = g / 255;
+  const bNorm = b / 255;
+  const max = Math.max(rNorm, gNorm, bNorm);
+  const min = Math.min(rNorm, gNorm, bNorm);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case rNorm:
+        h = (gNorm - bNorm) / d + (gNorm < bNorm ? 6 : 0);
+        break;
+      case gNorm:
+        h = (bNorm - rNorm) / d + 2;
+        break;
+      default:
+        h = (rNorm - gNorm) / d + 4;
+    }
+    h /= 6;
+  }
+
+  return { h: h * 360, s: s * 100, l: l * 100 };
+}
+
+function hslToRgb(h: number, s: number, l: number): { r: number; g: number; b: number } {
+  const hNorm = h / 360;
+  const sNorm = s / 100;
+  const lNorm = l / 100;
+
+  if (sNorm === 0) {
+    const gray = Math.round(lNorm * 255);
+    return { r: gray, g: gray, b: gray };
+  }
+
+  const hue2rgb = (p: number, q: number, t: number): number => {
+    let tNorm = t;
+    if (tNorm < 0) tNorm += 1;
+    if (tNorm > 1) tNorm -= 1;
+    if (tNorm < 1 / 6) return p + (q - p) * 6 * tNorm;
+    if (tNorm < 1 / 2) return q;
+    if (tNorm < 2 / 3) return p + (q - p) * (2 / 3 - tNorm) * 6;
+    return p;
+  };
+
+  const q = lNorm < 0.5 ? lNorm * (1 + sNorm) : lNorm + sNorm - lNorm * sNorm;
+  const p = 2 * lNorm - q;
+
+  return {
+    r: Math.round(hue2rgb(p, q, hNorm + 1 / 3) * 255),
+    g: Math.round(hue2rgb(p, q, hNorm) * 255),
+    b: Math.round(hue2rgb(p, q, hNorm - 1 / 3) * 255),
+  };
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  const toHex = (v: number) => v.toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`.toUpperCase();
+}
+
+export function getHexLightness(hex: string): number {
+  const { r, g, b } = hexToRgb(hex);
+  return rgbToHsl(r, g, b).l;
+}
+
+// 카드형(Small) 위젯의 이중 레이어 재해석([#169] 3.7절) — 배경색의 제목 영역을
+// "같은 색조·채도, 더 밝은 명도"로 계산한다. 95% 상한 clamp는 이미 밝은 색(흰색 등)이
+// 눈에 띄게 어두워지지 않도록 하는 안전장치.
+export function lightenHexColor(hex: string, deltaLightnessPoints: number, maxLightness = 95): string {
+  const { r, g, b } = hexToRgb(hex);
+  const { h, s, l } = rgbToHsl(r, g, b);
+  const nextL = Math.min(l + deltaLightnessPoints, maxLightness);
+  const { r: nr, g: ng, b: nb } = hslToRgb(h, s, nextL);
+  return rgbToHex(nr, ng, nb);
+}


### PR DESCRIPTION
## 이슈
Closes #213

**주의**: [PR #224 (#212)](https://github.com/MannaDevelopers/meditation_blossom_frontend/pull/224) 위에 쌓은 브랜치라 base를 `feature/issue-212`로 잡았습니다. #211 → #212 → #213 순서로 순차 머지되면 각 PR의 base가 자동으로 재조정됩니다.

## 요약
[#210 RN 공통](https://github.com/MannaDevelopers/meditation_blossom_frontend/issues/210)의 세 번째 단계. `WidgetPreview`가 `design: WidgetDesign`을 실시간으로 반영하고, 배너형(Large)/카드형(Small) 두 형태를 스와이프로 확인할 수 있게 했다.

## 변경점
- `WidgetPreview.tsx`
  - `design: WidgetDesign` prop 추가 (필수) — 텍스트 정렬/색상/크기/두께, 배경(단색/기본 그라데이션/갤러리) 실시간 반영
  - 305×480 프레임 안에서 좌우 스와이프로 배너형 ↔ 카드형 전환 (`ScrollView` + `pagingEnabled`, 신규 의존성 없음), 기본 진입은 배너형
  - 하단 페이지 인디케이터(점 2개, 활성 8×8 / 비활성 5×5)
  - 카드형(Small) 이중 레이어 재해석([#169] 3.7절): 배경색 → 제목 영역 HSL L+18%p(95% 상한) 밝은 톤 / 배경 갤러리 → 반투명 검정 스크림(38%) + 제목 텍스트 그림자 / 커스터마이징 안 함(기본 그라데이션) → 기존 동작 유지
  - 미리보기 텍스트에 `allowFontScaling={false}` 적용 ([#169] 5.1절)
- `src/utils/widgetDesignColor.ts` — `lightenHexColor`/`getHexLightness` 추가 (HSL 변환 기반 순수 함수)
- `src/constants/index.ts` — `WIDGET_TEXT_WEIGHT_FONT_FAMILY` 매핑 추가, `EditScreen.tsx`의 중복 정의 제거하고 공용 상수 참조하도록 정리
- `EditScreen.tsx` — `<WidgetPreview design={draftDesign} />` 연결, 크기/두께 선택 버튼("가")에 `allowFontScaling={false}` 적용

## 알려진 근사치 (Figma 대조 필요)
정확한 프레임/카드 치수(305×480 안에서 위젯 카드가 차지하는 비율, 여백 등)는 원본 Figma 목업 이미지에 접근할 수 없어 Android Large(245:115)/Small(177:115) 위젯의 최소 크기 비율만 기준으로 근사 배치했습니다. 리뷰 시 실제 목업과 대조해 조정이 필요할 수 있습니다.

## 범위 밖
- 배경 갤러리 이미지의 실제 선택/저장 ([#214](https://github.com/MannaDevelopers/meditation_blossom_frontend/issues/214)) — 렌더링 분기는 미리 구현해뒀지만 현재 UI에서 값을 설정할 방법은 없음
- 네이티브 위젯(Android/iOS) 반영

## 테스트
- [x] `lightenHexColor`/`getHexLightness` 단위 테스트 추가 (명도 상승, 95% clamp, 색조 유지 검증), `yarn jest` 통과
- [ ] (리뷰어 수동 확인) 텍스트/배경 값 변경 시 두 페이지 모두 실시간 반영, 스와이프 전환, 인디케이터 갱신